### PR TITLE
Windows fixes

### DIFF
--- a/crates/tracey-core/src/sources.rs
+++ b/crates/tracey-core/src/sources.rs
@@ -223,10 +223,11 @@ fn is_included(path: &Path, root: &Path, patterns: &[String]) -> bool {
     }
 
     let relative = path.strip_prefix(root).unwrap_or(path);
-    let relative_str = relative.to_string_lossy();
+    let relative_str = relative.to_string_lossy().replace('\\', "/");
 
     for pattern in patterns {
-        if matches_glob(&relative_str, pattern) {
+        let pattern = pattern.replace('\\', "/");
+        if matches_glob(&relative_str, &pattern) {
             return true;
         }
     }
@@ -237,10 +238,11 @@ fn is_included(path: &Path, root: &Path, patterns: &[String]) -> bool {
 #[cfg(feature = "walk")]
 fn is_excluded(path: &Path, root: &Path, patterns: &[String]) -> bool {
     let relative = path.strip_prefix(root).unwrap_or(path);
-    let relative_str = relative.to_string_lossy();
+    let relative_str = relative.to_string_lossy().replace('\\', "/");
 
     for pattern in patterns {
-        if matches_glob(&relative_str, pattern) {
+        let pattern = pattern.replace('\\', "/");
+        if matches_glob(&relative_str, &pattern) {
             return true;
         }
     }
@@ -250,6 +252,9 @@ fn is_excluded(path: &Path, root: &Path, patterns: &[String]) -> bool {
 
 #[cfg(feature = "walk")]
 fn matches_glob(path: &str, pattern: &str) -> bool {
+    assert!(!path.contains('\\'));
+    assert!(!pattern.contains('\\'));
+
     // Handle **/*.ext patterns (e.g., **/*.rs, **/*.swift, **/*.ts)
     if let Some(ext) = pattern.strip_prefix("**/*.") {
         return path.ends_with(&format!(".{}", ext));

--- a/crates/tracey/src/main.rs
+++ b/crates/tracey/src/main.rs
@@ -2290,6 +2290,10 @@ fn load_manifest_from_glob(root: &PathBuf, pattern: &str) -> Result<SpecManifest
 
 /// Simple glob pattern matching
 fn matches_glob(path: &str, pattern: &str) -> bool {
+    // Make path separators consistent in case of windows
+    let path = path.replace('\\', "/");
+    let pattern = pattern.replace('\\', "/");
+
     // Handle **/*.md pattern
     if pattern == "**/*.md" {
         return path.ends_with(".md");
@@ -2316,7 +2320,7 @@ fn matches_glob(path: &str, pattern: &str) -> bool {
         return true;
     }
 
-    let mut remaining = path;
+    let mut remaining = path.as_str();
     for part in parts {
         if let Some(idx) = remaining.find(part) {
             remaining = &remaining[idx + part.len()..];


### PR DESCRIPTION
- Fixes matrix dir-file separation by using the right separator
- Stop canonicalizing paths on windows. https://doc.rust-lang.org/std/fs/fn.canonicalize.html#platform-specific-behavior
- Let glob algorithms operate on linux style separators only

This last point is a bit meh in terms of perf. But at least it works. Just calls `replace` on the paths and patterns, but of course this is often not really needed (especially on Linux).
So let me know if you deem it acceptable or  whether you want me to change it.