### PR TITLE
Add cargo xtask with install subcommand

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2830,6 +2830,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "xtask"
+version = "0.1.0"
+
+[[package]]
 name = "zerocopy"
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[package.metadata]
+
+[package.metadata."docs.rs"]
+rustdoc-args = ["--html-in-header", "arborium-header.html"]
+
+[dependencies]

--- a/crates/xtask/arborium-header.html
+++ b/crates/xtask/arborium-header.html
@@ -1,0 +1,2 @@
+<!-- Rustdoc doesn't highlight some languages natively -- let's do it ourselves: https://github.com/bearcove/arborium -->
+<script defer src="https://cdn.jsdelivr.net/npm/@arborium/arborium@1/dist/arborium.iife.js"></script>

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,0 +1,30 @@
+use std::process::Command;
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    match args.first().map(|s| s.as_str()) {
+        Some("install") => install(),
+        Some(cmd) => {
+            eprintln!("Unknown command: {}", cmd);
+            eprintln!("Available commands: install");
+            std::process::exit(1);
+        }
+        None => {
+            eprintln!("Usage: cargo xtask <command>");
+            eprintln!("Available commands: install");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn install() {
+    let status = Command::new("cargo")
+        .args(["install", "--path", "./crates/tracey"])
+        .status()
+        .expect("Failed to run cargo install");
+
+    if !status.success() {
+        std::process::exit(status.code().unwrap_or(1));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a simple xtask for common development tasks.

## Usage

```bash
cargo xtask install
```

This runs `cargo install --path ./crates/tracey` to install tracey to `~/.cargo/bin`.