### PR TITLE
Improve error output on argument parse failure

### DIFF
--- a/crates/tracey/src/main.rs
+++ b/crates/tracey/src/main.rs
@@ -81,7 +81,11 @@ enum Command {
 }
 
 fn main() -> Result<()> {
-    let args: Args = args::from_std_args().expect("failed to parse arguments");
+    let Ok(args) = args::from_std_args::<Args>() else {
+        eprintln!("{}: failed to parse arguments", "error".bold().red());
+        print_help();
+        return Ok(());
+    };
 
     match args.command {
         // r[impl cli.serve]


### PR DESCRIPTION
Naively I tried `tracey build` and faced a wall of gibberish. This should be a bit more helpful.