### PR TITLE
:sparkles: Add php language support

### DIFF
--- a/crates/tracey-core/src/sources.rs
+++ b/crates/tracey-core/src/sources.rs
@@ -38,6 +38,7 @@ pub const SUPPORTED_EXTENSIONS: &[&str] = &[
     "groovy", // Groovy
     "cs",     // C#
     "zig",    // Zig
+    "php",    // PHP
 ];
 
 /// Check if a file extension is supported for scanning
@@ -473,6 +474,23 @@ mod tests {
     }
 
     #[test]
+    fn test_memory_sources_php() {
+        let result = Reqs::extract(
+            MemorySources::new()
+                .add("Foo.php", "// r[impl php.req.one]")
+                .add("Bar.php", "/* r[verify php.req.two] */")
+                .add("Baz.php", "/** r[verify php.req.three] */"),
+        )
+        .unwrap();
+
+        assert_eq!(result.reqs.len(), 3);
+        assert_eq!(result.reqs.references[0].req_id, "php.req.one");
+        assert_eq!(result.reqs.references[1].req_id, "php.req.two");
+        assert_eq!(result.reqs.references[2].req_id, "php.req.three");
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
     fn test_memory_sources_mixed_languages() {
         let result = Reqs::extract(
             MemorySources::new()
@@ -495,6 +513,7 @@ mod tests {
         assert!(is_supported_extension(OsStr::new("tsx")));
         assert!(is_supported_extension(OsStr::new("js")));
         assert!(is_supported_extension(OsStr::new("go")));
+        assert!(is_supported_extension(OsStr::new("php")));
 
         assert!(!is_supported_extension(OsStr::new("md")));
         assert!(!is_supported_extension(OsStr::new("txt")));


### PR DESCRIPTION
This adds support for php language.

Note that doing so I'm asking myself if that is relevant to have this "allow-list" of langauges. In fact I do not except the construct `r[<keyword> <speccode>]` to be present in natural code. So looking specifically for comments may just complexify the thing (also it forces to duplicate the information in case one want to use it in an `assert` directly).

So I think that it could be relevant to simply let the user provide (as command line argument) a glob pattern for spec as well as a glob pattern for code.

Maybe there could then have options to provide comment delimiters but I doubt this would reduce false-positives.