### PR TITLE
Replace leftover references to yaml config

### DIFF
--- a/crates/tracey/src/bridge/lsp.rs
+++ b/crates/tracey/src/bridge/lsp.rs
@@ -257,7 +257,7 @@ impl Backend {
         // Lock is now released
 
         // Publish config error diagnostic on config file
-        let config_path = project_root.join(".config/tracey/config.yaml");
+        let config_path = project_root.join(".config/tracey/config.styx");
         if let Ok(uri) = Url::from_file_path(&config_path) {
             if let Some(error_msg) = config_error {
                 let diagnostic = Diagnostic {

--- a/crates/tracey/src/daemon/client.rs
+++ b/crates/tracey/src/daemon/client.rs
@@ -50,7 +50,7 @@ impl DaemonConnector {
         let exe = std::env::current_exe().map_err(io::Error::other)?;
 
         // Determine config path
-        let config_path = self.project_root.join(".config/tracey/config.yaml");
+        let config_path = self.project_root.join(".config/tracey/config.styx");
 
         info!("Auto-starting daemon for {}", self.project_root.display());
 


### PR DESCRIPTION
I was trying out tracey today and I noticed that when `tracey web` started the daemon process, it was still looking for the config file at `.config/tracey/config.yaml`. This PR just replaces two lingering references to the yaml config after the styx migration.