### PR TITLE
Ship bundled AI skill and `tracey skill install` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,6 +1211,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,7 +1250,7 @@ checksum = "6738d2e996274e499bc7b0d693c858b7720b9cd2543a0643a3087e6cb0a4fa16"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1269,7 +1290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2294,7 +2315,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2397,6 +2418,16 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2727,7 +2758,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2796,6 +2827,12 @@ dependencies = [
  "libc",
  "pathdiff",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ownedbytes"
@@ -3143,6 +3180,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3455,7 +3503,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3983,7 +4031,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4264,6 +4312,7 @@ dependencies = [
  "async-trait",
  "axum",
  "blake3",
+ "dirs",
  "eyre",
  "facet",
  "facet-axum",
@@ -4760,7 +4809,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/tracey/Cargo.toml
+++ b/crates/tracey/Cargo.toml
@@ -97,6 +97,7 @@ open = "5"
 roam = { git = "https://github.com/bearcove/roam", branch = "main" }
 roam-stream = { git = "https://github.com/bearcove/roam", branch = "main" }
 roam-local = { git = "https://github.com/bearcove/roam", branch = "main" }
+dirs = "6.0.0"
 
 [features]
 default = ["search"]

--- a/crates/tracey/src/main.rs
+++ b/crates/tracey/src/main.rs
@@ -4,7 +4,7 @@
 //! (in the format `[rule.id]` in comments) and compares them against a spec
 //! manifest to produce coverage reports.
 
-use eyre::{Result, eyre};
+use eyre::{Result, WrapErr, eyre};
 use figue::{self as args, FigueBuiltins};
 use owo_colors::OwoColorize;
 use std::path::PathBuf;
@@ -112,6 +112,29 @@ enum Command {
         #[facet(args::positional, default)]
         root: Option<PathBuf>,
     },
+
+    /// Manage the bundled AI skill
+    Skill {
+        /// Skill action to perform
+        #[facet(args::subcommand)]
+        action: SkillAction,
+    },
+}
+
+/// Skill subcommands
+#[derive(Debug, facet::Facet)]
+#[repr(u8)]
+enum SkillAction {
+    /// Install the bundled Tracey skill for Claude and/or Codex
+    Install {
+        /// Install only for Claude Code
+        #[facet(args::named, default)]
+        claude: bool,
+
+        /// Install only for Codex CLI
+        #[facet(args::named, default)]
+        codex: bool,
+    },
 }
 
 // Embed the config schema for zero-execution discovery by styx tooling
@@ -192,6 +215,10 @@ fn main() -> Result<()> {
             let rt = tokio::runtime::Runtime::new()?;
             rt.block_on(kill_daemon(root))
         }
+        // r[impl cli.skill.install]
+        Command::Skill { action } => match action {
+            SkillAction::Install { claude, codex } => install_skill(claude, codex),
+        },
     }
 }
 
@@ -415,6 +442,58 @@ async fn show_status(root: Option<PathBuf>) -> Result<()> {
             println!("  The daemon may have crashed. Run 'tracey kill' to clean up.");
         }
     }
+
+    Ok(())
+}
+
+const SKILL_MD: &str = include_str!("../../../skill/SKILL.md");
+const SPEC_MD: &str = include_str!("../../../skill/references/tracey-spec.md");
+
+/// r[impl cli.skill.install]
+/// Install the bundled Tracey skill for Claude and/or Codex
+fn install_skill(claude_only: bool, codex_only: bool) -> Result<()> {
+    let home = dirs::home_dir().ok_or_else(|| eyre!("could not determine home directory"))?;
+
+    // If neither flag is set, install for both
+    let install_claude = !codex_only;
+    let install_codex = !claude_only;
+
+    let mut installed = Vec::new();
+
+    if install_claude {
+        let skill_dir = home.join(".claude/skills/tracey");
+        install_skill_to(&skill_dir)?;
+        installed.push(skill_dir);
+    }
+
+    if install_codex {
+        let skill_dir = home.join(".codex/skills/tracey");
+        install_skill_to(&skill_dir)?;
+        installed.push(skill_dir);
+    }
+
+    println!("{}: Tracey skill installed", "Success".green());
+    for path in &installed {
+        println!("  {}", path.display());
+    }
+
+    Ok(())
+}
+
+fn install_skill_to(skill_dir: &std::path::Path) -> Result<()> {
+    let refs_dir = skill_dir.join("references");
+    std::fs::create_dir_all(&refs_dir)
+        .wrap_err_with(|| format!("failed to create {}", refs_dir.display()))?;
+
+    std::fs::write(skill_dir.join("SKILL.md"), SKILL_MD)
+        .wrap_err_with(|| format!("failed to write {}", skill_dir.join("SKILL.md").display()))?;
+
+    std::fs::write(refs_dir.join("tracey-spec.md"), SPEC_MD).wrap_err_with(|| {
+        format!(
+            "failed to write {}",
+            refs_dir.join("tracey-spec.md").display()
+        )
+    })?;
 
     Ok(())
 }

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: tracey
+description: Add proper Tracey spec annotations to code, find requirements, and check coverage. Use when working with projects that have Tracey configuration (.config/tracey/config.styx), when adding spec references to code, or when checking requirement coverage.
+---
+
+# Tracey
+
+Add proper spec annotations to code using Tracey's requirement tracking system.
+
+## Overview
+
+Tracey maintains traceability between specification requirements and code. This skill helps add proper `r[impl req.id]` and `r[verify req.id]` annotations to code, find which requirements need implementation or testing, and understand Tracey annotation syntax.
+
+**Primary Interface:** Use Tracey MCP tools (`tracey_status`, `tracey_uncovered`, `tracey_untested`, `tracey_rule`, `tracey_unmapped`) to discover requirements and validate coverage. The MCP tools provide self-documenting output showing which prefixes to use and what requirements need work.
+
+## When to Use
+
+Use this skill when:
+- Working with a project that has `.config/tracey/config.styx`
+- User asks to "add spec annotations" or "annotate with requirements"
+- Need to find which requirements are uncovered or untested
+- Writing code that implements spec requirements
+- Writing tests that verify spec requirements
+
+## Quick Reference: MCP Tools
+
+| Tool | Purpose |
+|------|---------|
+| `tracey_status` | See configured specs, prefixes, and coverage percentages |
+| `tracey_uncovered` | List requirements without implementation |
+| `tracey_untested` | List requirements without verification/tests |
+| `tracey_unmapped` | Show code that lacks requirement references |
+| `tracey_rule <id>` | Get full details about a specific requirement |
+
+**Tip:** Start with `tracey_status` to see what prefix to use (e.g., `r[...]` vs `shm[...]`), then use `tracey_uncovered` or `tracey_untested` to find work that needs doing.
+
+## Workflow: Adding Annotations
+
+### Step 1: Check Configuration and Prefixes
+
+Use the `tracey_status` MCP tool to see configured specs and their prefixes:
+
+```
+tracey_status
+```
+
+This shows:
+- Which specs are configured (e.g., `rapace`, `shm`, `rust`)
+- What prefix to use for each (e.g., `r[...]`, `shm[...]`, `rs[...]`)
+- Current coverage percentages by implementation
+
+**Example output:**
+```
+## Configured Specs
+
+- **rapace** (prefix: `r`)
+  - When annotating code, use: `r[impl rule.id]` or `r[verify rule.id]`
+
+- **shm** (prefix: `shm`)
+  - When annotating code, use: `shm[impl rule.id]` or `shm[verify rule.id]`
+```
+
+### Step 2: Find Relevant Requirements
+
+Use Tracey MCP tools to discover which requirements need work:
+
+**Find requirements without implementation:**
+```
+tracey_uncovered --spec_impl "rapace/rust"
+```
+
+**Find requirements without tests:**
+```
+tracey_untested --spec_impl "rapace/typescript"
+```
+
+**Get details about a specific requirement:**
+```
+tracey_rule "message.hello.timing"
+```
+
+**See which code lacks requirement references:**
+```
+tracey_unmapped --path "src/auth/"
+```
+
+### Step 3: Add Annotations
+
+Add comments above relevant code using `PREFIX[VERB REQ]` syntax:
+
+```rust
+// r[impl auth.token.validation]
+fn validate_token(token: &str) -> bool {
+    // implementation
+}
+```
+
+For tests:
+
+```rust
+// r[verify auth.token.validation]
+#[test]
+fn test_token_validation() {
+    assert!(validate_token("valid"));
+}
+```
+
+### Step 4: Validate
+
+Use `tracey_status` to verify your annotations were detected and coverage improved:
+
+```
+tracey_status
+```
+
+Check that the implementation/verification percentages increased for your target spec/impl combination.
+
+## Annotation Syntax
+
+### Supported Verbs
+
+- **`impl`** - This code implements the requirement (default if verb omitted)
+- **`verify`** - This code tests/verifies the requirement
+- **`depends`** - This code must be reviewed if the requirement changes
+- **`related`** - Loosely connected, shown when reviewing related code
+
+### Language-Specific Examples
+
+**Rust:**
+```rust
+// r[impl database.connection]
+fn connect_to_db() -> Result<Connection> { ... }
+
+/// r[verify database.connection]
+#[test]
+fn test_connection() { ... }
+```
+
+**TypeScript:**
+```typescript
+// r[impl api.error.format]
+function formatError(code: number, message: string) { ... }
+
+// r[verify api.error.format]
+test('error format', () => { ... });
+```
+
+**Python:**
+```python
+# r[impl auth.validation]
+def validate_user(token: str) -> bool:
+    pass
+
+# r[verify auth.validation]
+def test_validate_user():
+    pass
+```
+
+**Swift:**
+```swift
+// r[impl session.timeout]
+func cleanupExpiredSessions() { ... }
+
+// r[verify session.timeout]
+func testSessionTimeout() { ... }
+```
+
+## Common Patterns
+
+### Multiple Requirements
+
+One implementation can satisfy multiple requirements:
+
+```rust
+// r[impl auth.validation]
+// r[impl auth.rate-limiting]
+fn validate_with_rate_limit() { ... }
+```
+
+### Generated Code
+
+Annotate generators, not generated code:
+
+```rust
+// r[impl codegen.service-dispatch]
+fn generate_dispatcher(service: &ServiceDetail) -> String {
+    // Code generator that produces dispatchers
+}
+```
+
+### Partial Implementation
+
+Use clear context when one requirement has multiple implementing functions:
+
+```rust
+// r[impl database.connection] - connection pooling
+fn create_pool() { ... }
+
+// r[impl database.connection] - connection lifecycle
+fn close_connection() { ... }
+```
+
+## Configuration Example
+
+**Note:** Instead of manually reading the config file, use `tracey_status` to see configured specs, prefixes, and implementations.
+
+Typical `.config/tracey/config.styx`:
+
+```styx
+specs (
+    {
+        name my-project
+        prefix r
+        include (docs/spec/**/*.md)
+        impls (
+            {
+                name rust
+                include (
+                    crates/**/*.rs
+                )
+                exclude (target/**)
+            }
+            {
+                name typescript
+                include (src/**/*.ts)
+            }
+        )
+    }
+)
+```
+
+Key fields:
+- `prefix` - Used in annotations (e.g., `r[...]`)
+- `include` (spec) - Glob patterns for spec markdown files, as a sequence `(...)`
+- `impls` - Sequence of implementation blocks
+- `include` (impl) - Glob patterns for source files to scan, as a sequence `(...)`
+- `exclude` (impl) - Glob patterns to exclude, as a sequence `(...)`
+
+## Troubleshooting
+
+**Error: Unknown prefix**
+- Check the prefix in `.config/tracey/config.styx`
+- Ensure annotations use the correct prefix
+
+**Requirements not found**
+- Verify requirement IDs match exactly (case-sensitive, dot-separated)
+- Check that spec markdown files are in the configured `include` paths
+
+**Annotations not detected**
+- Ensure annotations are in comments (not strings)
+- Check that source files match the `include` patterns in config
+
+## Reference Documentation
+
+For detailed information about Tracey's implementation, configuration schema, and tooling, see the `references/tracey-spec.md` file bundled with this skill.

--- a/skill/references/tracey-spec.md
+++ b/skill/references/tracey-spec.md
@@ -1,0 +1,781 @@
+# Tracey Specification
+
+## Introduction
+
+Tracey maintains traceability between specifications and code. Specs, implementations, and tests drift apart—code changes without updating specs, specs describe unimplemented features, tests cover different scenarios than requirements specify.
+
+Tracey uses lightweight annotations in markdown and source code comments to link specification requirements with implementing code, tests, and dependencies. This enables:
+
+- Verifying multiple implementations (different languages, platforms) match the same spec
+- Finding which requirements lack implementation or tests
+- Seeing which requirement justifies each piece of code
+- Analyzing impact when requirements or code changes
+
+This document has two parts: **Language** (annotation syntax) and **Tooling** (tracey implementation).
+
+## Nomenclature
+
+To avoid confusion, we define these terms precisely and use them consistently:
+
+**Specification** (or **spec**)
+A set of requirements, typically written as a human-readable document.
+
+**Requirement** (or **req**)
+A single, positive (MUST, not MUST NOT) property of the system that is both implementable and testable. Each requirement should describe one specific behavior or constraint.
+
+**Implementation**
+Code that fulfills a requirement's behavior or constraint.
+
+**Test**
+Code that verifies an implementation correctly fulfills a requirement, typically containing assertions run by a test harness.
+
+**Important distinctions:**
+- A **spec** is a document containing requirements. **Tests** are executable code. Don't use "spec" to mean "test file" (as some test frameworks do).
+- Other projects may use "rule" to mean requirement. We don't use that term—use "requirement" or "req" instead.
+
+---
+
+# Language
+
+This section specifies the annotation language: how to define requirements in markdown specifications and reference them in source code.
+
+## Requirement Definitions in Markdown
+
+Requirements are defined in markdown specification documents using the syntax `PREFIX[REQ]` where PREFIX is the spec's configured prefix and REQ is a requirement ID.
+
+### Markdown Requirement Syntax
+
+> r[markdown.syntax.marker]
+> A requirement definition MUST be written as `PREFIX[REQ]` in one of two contexts: as a standalone paragraph starting at column 0, or inside a blockquote. The PREFIX identifies which spec this requirement belongs to (configured via `prefix` in the spec configuration). The VERB is implicitly "define" in markdown (unlike source code which uses explicit verbs like `r[impl REQ]`).
+>
+> Valid (standalone):
+> ```markdown
+> r[auth.token.validation]
+> The system must validate tokens before granting access.
+> ```
+>
+> Valid (in blockquote for multi-paragraph content):
+> ```markdown
+> > r[api.error.format]
+> > API errors must follow this format:
+> >
+> > ```json
+> > {"error": "message", "code": 400}
+> > ```
+> ```
+
+> r[markdown.syntax.inline-ignored]
+> Requirement markers that appear inline within other text MUST be treated as regular text, not requirement definitions.
+>
+> Valid (defines requirement):
+> ```markdown
+> r[database.connection]
+> When connecting to the database...
+> ```
+>
+> Invalid (treated as text, not a definition):
+> ```markdown
+> When implementing r[database.connection] you should...
+> ```
+
+### Duplicate Detection
+
+> r[markdown.duplicates.same-file]
+> If the same requirement ID appears multiple times in a single markdown file, an error MUST be reported.
+>
+> Invalid:
+> ```markdown
+> r[auth.validation]
+> Users must authenticate.
+>
+> Later in the same file...
+>
+> r[auth.validation]
+> This causes an error - duplicate requirement ID!
+> ```
+
+> r[markdown.duplicates.cross-file]
+> If the same requirement ID appears in multiple markdown files within the same spec, an error MUST be reported when merging manifests. Requirement IDs only need to be unique within a single spec; different specs may use the same requirement ID since they have different prefixes.
+>
+> Invalid (same spec):
+> ```markdown
+> # docs/spec/auth.md (tracey spec, prefix "r")
+> r[api.format]
+> API responses must use JSON.
+>
+> # docs/spec/api.md (tracey spec, prefix "r")
+> r[api.format]
+> Error - this requirement ID is already defined in auth.md within the same spec!
+> ```
+>
+> Valid (different specs):
+> ```markdown
+> # docs/tracey/spec.md (tracey spec, prefix "r")
+> r[api.format]
+> API responses must use JSON.
+>
+> # vendor/messaging-spec/spec.md (messaging spec, prefix "m")
+> m[api.format]
+> OK - different spec, different prefix, no conflict.
+> ```
+
+## Requirement References in Source Code
+
+Requirement references are extracted from source code comments using the syntax `PREFIX[VERB REQ]` where PREFIX matches a configured spec's prefix.
+
+### Basic Syntax
+
+r[ref.syntax.brackets]
+A requirement reference MUST be written as `PREFIX[VERB REQ]` within a comment, where PREFIX identifies which spec is being referenced (matching the `prefix` field in the spec configuration).
+
+> r[ref.syntax.verb]
+> VERB indicates the relationship type (impl, verify, depends, related).
+> 
+> If omitted, defaults to `impl`.
+
+> r[ref.syntax.req-id]
+> REQ is a requirement ID consisting of dot-separated segments.
+>
+> Each segment MUST contain only ASCII letters (a-z, A-Z), digits (0-9), hyphens, or underscores. This restriction ensures requirement IDs work cleanly in URLs without encoding issues.
+
+> r[ref.syntax.surrounding-text]
+> The annotation MAY be surrounded by other text within the comment. Any characters (including punctuation) after the closing `]` are ignored by the parser.
+>
+> Valid:
+> ```rust
+> // r[impl auth.token.validation]       // tracey spec (prefix "r")
+> // r[verify user-profile.update_email] // tracey spec
+> // m[depends crypto_v2.algorithm]      // messaging spec (prefix "m")
+> // h2[impl api.v1.users]               // http2 spec (prefix "h2")
+> // r[message.hello.timing]: send Hello immediately
+> // See r[auth.requirements] for details.
+> ```
+>
+> Invalid:
+> ```rust
+> // r[impl auth..token]           // empty segment
+> // r[verify user.profile!update] // exclamation mark not allowed
+> // r[depends .crypto.algorithm]  // leading dot
+> // r[impl api.users.]            // trailing dot
+> // r[verify user profile.update] // space not allowed
+> // r[impl auth.🔐.token]         // emoji not allowed
+> // r[verify café.menu]           // accented characters not allowed
+> ```
+
+### Supported Verbs
+
+Source code references use verbs to indicate the relationship between code and requirements:
+
+> r[ref.verb.impl]
+> The `impl` verb MUST be interpreted as indicating that the code implements the referenced requirement.
+>
+> ```rust
+> // r[impl auth.token.validation]
+> fn validate_token(token: &str) -> bool {
+>     // etc.
+> }
+> ```
+
+> r[ref.verb.verify]
+> The `verify` verb MUST be interpreted as indicating that the code tests or verifies the referenced requirement.
+>
+> ```typescript
+> test('token validation', () => {
+>     // r[verify auth.token.validation]
+>     expect(validateToken('abc')).toBe(true);
+> });
+> ```
+
+> r[ref.verb.depends]
+> The `depends` verb MUST be interpreted as indicating a strict dependency — the code must be rechecked if the referenced requirement changes.
+>
+> ```python
+> # r[depends auth.crypto.algorithm]
+> # This code must be reviewed if the crypto algorithm changes
+> def hash_password(password: str) -> str:
+>     return bcrypt.hashpw(password.encode(), bcrypt.gensalt())
+> ```
+
+> r[ref.verb.related]
+> The `related` verb MUST be interpreted as indicating a loose connection, shown when reviewing related code.
+>
+> ```swift
+> // r[related user.session.timeout]
+> // Session cleanup is related to timeout requirements
+> func cleanupExpiredSessions() {
+>     sessions.removeAll { $0.isExpired }
+> }
+> ```
+
+> r[ref.verb.default]
+> When no verb is provided, the reference SHOULD be treated as an `impl` reference.
+>
+> ```go
+> // r[auth.token.validation] - no verb, defaults to 'impl'
+> func ValidateToken(token string) bool {
+>     return len(token) > 0
+> }
+> ```
+
+### Comment Types
+
+r[ref.comments.line]
+Requirement references MUST be recognized in line comments (`//`, `#`, etc. depending on language).
+
+r[ref.comments.block]
+Requirement references MUST be recognized in block comments (`/* */`, `""" """`, etc. depending on language).
+
+r[ref.comments.doc]
+Requirement references MUST be recognized in documentation comments (`///`, `//!`, `/** */`, etc. depending on language).
+
+### Source Location Tracking
+
+r[ref.span.offset]
+Each extracted requirement reference MUST include the byte offset of its location in the source file.
+
+r[ref.span.length]
+Each extracted requirement reference MUST include the byte length of the reference.
+
+r[ref.span.file]
+Each extracted requirement reference MUST include the path to the source file.
+
+---
+
+# Tooling
+
+This section specifies how the tracey tool processes annotations, computes coverage, and exposes results.
+
+## Coverage Computation
+
+r[coverage.compute.percentage]
+Coverage percentage MUST be calculated as (covered requirements / total requirements) * 100.
+
+r[coverage.compute.covered]
+Tracey MUST consider a requirement covered if at least one reference to it exists in the scanned source files.
+
+r[coverage.compute.uncovered]
+Requirements in the manifest with no references MUST be reported as uncovered.
+
+r[coverage.compute.invalid]
+References to requirement IDs not present in the manifest MUST be reported as invalid.
+
+## Reference Extraction
+
+r[ref.verb.unknown]
+When an unrecognized verb is encountered, tracey MUST emit a warning but SHOULD still extract the requirement reference.
+
+r[ref.prefix.unknown]
+When a reference uses a prefix that does not match any configured spec, tracey MUST report an error indicating the unknown prefix and list the available spec prefixes.
+
+r[ref.prefix.matching]
+When extracting references from source code, tracey MUST match the prefix against configured specs to determine which spec's requirement namespace to query.
+
+## Markdown Processing
+
+### HTML Output
+
+> r[markdown.html.div]
+> When transforming markdown, each requirement marker MUST be replaced with a `<div>` element with class `requirement`.
+>
+> Input:
+> ```markdown
+> r[auth.token.validation]
+> ```
+>
+> Output:
+> ```html
+> <div class="requirement" id="r-auth.token.validation">
+>   <a href="#r-auth.token.validation">auth.<wbr>token.<wbr>validation</a>
+> </div>
+> ```
+
+> r[markdown.html.anchor]
+> The generated div MUST have an `id` attribute in the format `r-{req.id}` for linking.
+>
+> ```html
+> <div class="requirement" id="r-api.response.format">
+> ```
+
+> r[markdown.html.link]
+> The generated div MUST contain a link (`<a>`) pointing to its own anchor.
+>
+> ```html
+> <a href="#r-user.login.flow">user.<wbr>login.<wbr>flow</a>
+> ```
+
+> r[markdown.html.wbr]
+> Dots in the displayed requirement ID SHOULD be followed by `<wbr>` elements to allow line breaking.
+>
+> ```html
+> database.<wbr>connection.<wbr>pool
+> ```
+
+## Configuration
+
+r[config.format.kdl]
+The configuration file MUST be in KDL format.
+
+r[config.path.default]
+The default configuration path MUST be `.config/tracey/config.kdl` relative to the project root.
+
+> r[config.schema]
+> The configuration MUST follow this schema:
+>
+> ```kdl
+> spec {
+>     name "tracey"
+>     prefix "r"
+>     include "docs/spec/**/*.md"
+>
+>     impl {
+>         name "rust"
+>         include "crates/**/*.rs"
+>         exclude "target/**"
+>     }
+> }
+>
+> spec {
+>     name "messaging-protocol"
+>     prefix "m"
+>     include "vendor/messaging-spec/**/*.md"
+>     source_url "https://github.com/example/messaging-spec"
+>
+>     impl {
+>         name "rust"
+>         include "crates/**/*.rs"
+>     }
+> }
+> ```
+
+r[config.spec.name]
+Each spec configuration MUST have a `name` child node with the spec name as its argument.
+
+r[config.spec.prefix]
+Each spec configuration MUST have a `prefix` child node specifying the single-character or multi-character prefix used to identify this spec in markdown and source code annotations.
+
+r[config.spec.include]
+Each spec configuration MUST have one or more `include` child nodes specifying glob patterns for markdown files containing requirement definitions.
+
+r[config.spec.source-url]
+Each spec configuration MAY have a `source_url` child node providing the canonical URL for the specification (e.g., a GitHub repository). This URL is used for attribution in the dashboard and documentation.
+
+r[config.impl.name]
+Each impl configuration MUST have a `name` child node identifying the implementation (e.g., "main", "core").
+
+r[config.impl.include]
+Each impl configuration MAY have one or more `include` child nodes specifying glob patterns for source files to scan.
+
+r[config.impl.exclude]
+Each impl configuration MAY have one or more `exclude` child nodes specifying glob patterns for source files to exclude.
+
+### Multiple Specs and Remote Specs
+
+r[config.multi-spec.prefix-namespace]
+When multiple specs are configured, the prefix serves as the namespace to disambiguate which spec a requirement belongs to.
+
+r[config.multi-spec.unique-within-spec]
+Requirement IDs MUST be unique within a single spec, but MAY be duplicated across different specs (since they use different prefixes).
+
+r[config.remote-spec.local-files]
+Remote specifications MUST be obtained as local files before tracey can process them. Users can use git submodules, manual downloads, or any other method to obtain spec files locally.
+
+> r[config.remote-spec.workflow]
+> The recommended workflow for implementing a remote specification is:
+>
+> 1. Obtain the spec files locally (e.g., via git submodule or download)
+> 2. Configure the spec with `include` pointing to the local files
+> 3. Set `source_url` to the canonical spec location for attribution
+> 4. Use the spec's configured prefix in source code annotations
+>
+> Example:
+> ```kdl
+> spec {
+>     name "http2"
+>     prefix "h2"
+>     include "vendor/http2-spec/docs/**/*.md"
+>     source_url "https://github.com/http2/spec"
+>
+>     impl {
+>         name "rust"
+>         include "crates/http2/**/*.rs"
+>     }
+> }
+> ```
+
+## File Walking
+
+r[walk.gitignore]
+File walking MUST respect `.gitignore` files.
+
+r[walk.default-include]
+When no include patterns are specified, tracey MUST default to `**/*.rs`.
+
+## Dashboard
+
+Tracey provides a web-based dashboard for browsing specifications, viewing coverage, and navigating source code.
+
+### URL Scheme
+
+r[dashboard.url.structure]
+Dashboard URLs MUST follow the structure `/{specName}/{impl}/{view}` where `{specName}` is the name of a configured spec and `{impl}` is an implementation name.
+
+r[dashboard.url.spec-view]
+The specification view MUST be accessible at `/{specName}/{impl}/spec` with optional heading hash fragment `/{specName}/{impl}/spec#{headingSlug}`.
+
+r[dashboard.url.coverage-view]
+The coverage view MUST be accessible at `/{specName}/{impl}/coverage` with optional query parameters `?filter=impl|verify` and `?level=must|should|may`.
+
+r[dashboard.url.sources-view]
+The sources view MUST be accessible at `/{specName}/{impl}/sources` with optional file and line parameters `/{specName}/{impl}/sources/{filePath}:{lineNumber}`.
+
+r[dashboard.url.context]
+Source URLs MAY include a `?context={reqId}` query parameter to show requirement context in the sidebar.
+
+r[dashboard.url.root-redirect]
+Navigating to `/` MUST redirect to `/{defaultSpec}/{defaultImpl}/spec` where `{defaultSpec}` is the first configured spec and `{defaultImpl}` is its first implementation.
+
+r[dashboard.url.invalid-spec]
+Navigating to an invalid spec name SHOULD redirect to the first valid spec or display an error.
+
+### API Endpoints
+
+r[dashboard.api.config]
+The `/api/config` endpoint MUST return the project configuration including `projectRoot` and `specs` array.
+
+r[dashboard.api.spec]
+The `/api/spec?spec={specName}&impl={impl}` endpoint MUST return the rendered HTML and outline for the named spec and implementation.
+
+r[dashboard.api.forward]
+The `/api/forward?spec={specName}&impl={impl}` endpoint MUST return the forward mapping (requirements to file references) for the specified implementation.
+
+r[dashboard.api.reverse]
+The `/api/reverse?spec={specName}&impl={impl}` endpoint MUST return the reverse mapping (files to requirement references) with coverage statistics for the specified implementation.
+
+r[dashboard.api.file]
+The `/api/file?spec={specName}&impl={impl}&path={filePath}` endpoint MUST return the file content, syntax-highlighted HTML, and code unit annotations.
+
+r[dashboard.api.version]
+The `/api/version` endpoint MUST return a version string that changes when any source data changes.
+
+r[dashboard.api.version-polling]
+The dashboard SHOULD poll `/api/version` and refetch data when the version changes.
+
+### Link Generation
+
+r[dashboard.links.spec-aware]
+All links generated in rendered markdown MUST include the spec name and implementation as the first two path segments.
+
+r[dashboard.links.req-links]
+Requirement ID badges MUST link to `/{specName}/{impl}/spec?req={reqId}` to navigate to the requirement in the specification.
+
+r[dashboard.links.impl-refs]
+Implementation reference badges MUST link to `/{specName}/{impl}/sources/{filePath}:{line}?context={reqId}`.
+
+r[dashboard.links.verify-refs]
+Verification/test reference badges MUST link to `/{specName}/{impl}/sources/{filePath}:{line}?context={reqId}`.
+
+r[dashboard.links.heading-links]
+Heading links in the outline MUST link to `/{specName}/{impl}/spec#{headingSlug}`.
+
+### Specification View
+
+r[dashboard.spec.outline]
+The specification view MUST display a collapsible outline tree of headings in a sidebar.
+
+r[dashboard.spec.outline-coverage]
+Each outline heading SHOULD display a coverage indicator showing the ratio of covered requirements within that section.
+
+r[dashboard.spec.content]
+The specification view MUST display the rendered markdown content with requirement containers.
+
+r[dashboard.spec.req-highlight]
+When navigating to a requirement via URL parameter `?req={reqId}`, the requirement container MUST be highlighted and scrolled into view.
+
+r[dashboard.spec.heading-scroll]
+When navigating to a heading via URL path, the heading MUST be scrolled into view.
+
+r[dashboard.spec.switcher]
+The header MUST always display spec and implementation switcher dropdowns, even when only one option is available.
+
+r[dashboard.spec.switcher-single]
+When only one spec or implementation is configured, the switcher MUST still be visible (showing the single option).
+
+### Coverage View
+
+r[dashboard.coverage.table]
+The coverage view MUST display a table of all requirements with their coverage status.
+
+r[dashboard.coverage.filter-type]
+The coverage view MUST support filtering by reference type (impl, verify, or all).
+
+r[dashboard.coverage.filter-level]
+The coverage view MUST support filtering by RFC 2119 level (MUST, SHOULD, MAY, or all).
+
+r[dashboard.coverage.stats]
+The coverage view MUST display summary statistics including total requirements, covered count, and coverage percentage.
+
+r[dashboard.coverage.req-links]
+Each requirement in the coverage table MUST link to the requirement in the specification view.
+
+r[dashboard.coverage.ref-links]
+Each reference in the coverage table MUST link to the source location.
+
+### Sources View
+
+r[dashboard.sources.file-tree]
+The sources view MUST display a collapsible file tree in a sidebar.
+
+r[dashboard.sources.tree-coverage]
+Each folder and file in the tree SHOULD display a coverage percentage badge.
+
+r[dashboard.sources.code-view]
+When a file is selected, the sources view MUST display the syntax-highlighted source code.
+
+r[dashboard.sources.line-numbers]
+The code view MUST display line numbers.
+
+r[dashboard.sources.line-annotations]
+Lines containing requirement references MUST be annotated with indicators showing which requirements are referenced.
+
+r[dashboard.sources.line-highlight]
+When navigating to a specific line, that line MUST be highlighted and scrolled into view.
+
+r[dashboard.sources.req-context]
+When a `?context={reqId}` parameter is present, the sidebar MUST display the requirement details and all its references.
+
+r[dashboard.sources.editor-open]
+Clicking a line number SHOULD open the file at that line in the configured editor.
+
+### Search
+
+r[dashboard.search.modal]
+The search modal MUST be openable via keyboard shortcut (Cmd+K on Mac, Ctrl+K elsewhere).
+
+r[dashboard.search.reqs]
+Search MUST support finding requirements by ID or text content.
+
+r[dashboard.search.files]
+Search MUST support finding files by path.
+
+r[dashboard.search.navigation]
+Selecting a search result MUST navigate to the appropriate view (spec for requirements, sources for files).
+
+### Header
+
+r[dashboard.header.nav-tabs]
+The header MUST display navigation tabs for Specification, Coverage, and Sources views.
+
+r[dashboard.header.nav-active]
+The active view tab MUST be visually distinguished.
+
+r[dashboard.header.nav-preserve-spec]
+Navigation tabs MUST preserve the current spec name and language when switching views.
+
+r[dashboard.header.search]
+The header MUST display a search input that opens the search modal when clicked or focused.
+
+r[dashboard.header.logo]
+The header MUST display a "tracey" link to the project repository.
+
+## Command Line Interface
+
+Tracey provides a minimal command-line interface focused on serving.
+
+### Commands
+
+r[cli.no-args]
+When invoked with no subcommand, tracey MUST display help text listing available commands.
+
+r[cli.serve]
+The `tracey serve` command MUST start the HTTP dashboard server.
+
+r[cli.mcp]
+The `tracey mcp` command MUST start an MCP (Model Context Protocol) server over stdio.
+
+## Server Architecture
+
+Both `tracey serve` (HTTP) and `tracey mcp` (MCP) share a common headless server core.
+
+### File Watching
+
+r[server.watch.sources]
+The server MUST watch source files for changes and update coverage data automatically.
+
+r[server.watch.specs]
+The server MUST watch specification markdown files for changes and update requirement data automatically.
+
+r[server.watch.config]
+The server MUST watch its configuration file for changes and reload configuration automatically.
+
+r[server.watch.debounce]
+File change events SHOULD be debounced to avoid excessive recomputation during rapid edits.
+
+### State Management
+
+r[server.state.shared]
+Both HTTP and MCP modes MUST use the same underlying coverage computation and state.
+
+r[server.state.version]
+The server MUST maintain a version identifier that changes when any source data changes.
+
+## Validation
+
+Tracey validates the integrity and quality of requirement definitions and references.
+
+r[validation.broken-refs]
+The system MUST detect and report references to non-existent requirement IDs in implementation and verification comments.
+
+r[validation.naming]
+The system MUST validate that requirement IDs follow the configured naming convention (e.g., section.subsection.name format).
+
+r[validation.circular-deps]
+The system MUST detect circular dependencies if requirements reference each other, preventing infinite loops in dependency resolution.
+
+r[validation.orphaned]
+The system MUST identify requirements that are defined in specs but never referenced in implementation or verification comments.
+
+r[validation.duplicates]
+The system MUST detect duplicate requirement IDs across all spec files.
+
+## MCP Server
+
+The MCP server exposes tracey functionality as tools for AI assistants.
+
+### Response Format
+
+r[mcp.response.header]
+Every MCP tool response MUST begin with a status line showing current coverage for all spec/implementation combinations.
+
+> r[mcp.response.header-format]
+> The header MUST follow this format:
+>
+> ```
+> tracey | spec1/impl1: 72% | spec2/impl2: 45%
+> ```
+
+r[mcp.response.delta]
+Every MCP tool response MUST include a delta section showing changes since the last query in this session.
+
+> r[mcp.response.delta-format]
+> The delta section MUST follow this format:
+>
+> ```
+> Since last query:
+>   ✓ req.id.one → src/file.rs:42
+>   ✓ req.id.two → src/other.rs:67
+> ```
+>
+> If no changes occurred, display: `(no changes since last query)`
+
+r[mcp.response.hints]
+Tool responses SHOULD include hints showing how to drill down or query further.
+
+r[mcp.response.text]
+Tool responses MUST be formatted as human-readable text/markdown, not JSON.
+
+### Spec/Implementation Selection
+
+r[mcp.select.single]
+When only one spec and one implementation are configured, tools MUST use them by default without requiring explicit selection.
+
+r[mcp.select.spec-only]
+When a spec has only one implementation, specifying just the spec name MUST be sufficient.
+
+r[mcp.select.full]
+The full `spec/impl` syntax MUST be supported for explicit selection when multiple options exist.
+
+r[mcp.select.ambiguous]
+When selection is ambiguous and not provided, tools MUST return an error listing available options.
+
+### Tools
+
+r[mcp.tool.status]
+The `tracey_status` tool MUST return a coverage overview and list available query commands.
+
+r[mcp.tool.uncovered]
+The `tracey_uncovered` tool MUST return requirements without `impl` references, grouped by markdown section.
+
+r[mcp.tool.uncovered-section]
+The `tracey_uncovered` tool MUST support a `--section` parameter to filter to a specific section.
+
+r[mcp.tool.untested]
+The `tracey_untested` tool MUST return requirements without `verify` references, grouped by markdown section.
+
+r[mcp.tool.untested-section]
+The `tracey_untested` tool MUST support a `--section` parameter to filter to a specific section.
+
+r[mcp.tool.unmapped]
+The `tracey_unmapped` tool MUST return a tree view of source files with coverage percentages.
+
+> r[mcp.tool.unmapped-tree]
+> The tree view MUST use ASCII art formatting similar to the `tree` command:
+>
+> ```
+> src/
+> ├── channel/           82% ████████░░
+> │   ├── flow.rs        95% █████████░
+> │   └── close.rs       45% ████░░░░░░
+> └── error/             34% ███░░░░░░░
+> ```
+
+r[mcp.tool.unmapped-zoom]
+The `tracey_unmapped` tool MUST accept an optional path parameter to zoom into a specific directory or file.
+
+r[mcp.tool.unmapped-file]
+When zoomed into a specific file, `tracey_unmapped` MUST list individual unmapped code units with line numbers.
+
+r[mcp.tool.req]
+The `tracey_req` tool MUST return the full text of a requirement and all references to it.
+
+### Configuration Tools
+
+r[mcp.config.exclude]
+The `tracey_config_exclude` tool MUST allow adding exclude patterns to filter out files from scanning.
+
+r[mcp.config.include]
+The `tracey_config_include` tool MUST allow adding include patterns to expand the set of scanned files.
+
+r[mcp.config.list]
+The `tracey_config` tool MUST display the current configuration for all specs and implementations.
+
+r[mcp.config.persist]
+Configuration changes made via MCP tools MUST be persisted to the configuration file.
+
+### Progressive Discovery
+
+r[mcp.discovery.overview-first]
+Initial queries SHOULD return summarized results with counts per section/directory.
+
+r[mcp.discovery.drill-down]
+Responses MUST include hints showing how to query for more specific results.
+
+r[mcp.discovery.pagination]
+Large result sets SHOULD be paginated with hints showing how to retrieve more results.
+
+### Validation Tools
+
+r[mcp.validation.check]
+The `tracey_validate` tool MUST run all validation checks and return a report of issues found (broken refs, naming violations, circular deps, orphaned requirements, duplicates).
+
+r[dashboard.validation.display]
+The dashboard MUST display validation errors prominently, with links to the problematic locations.
+
+r[dashboard.validation.continuous]
+The dashboard SHOULD run validation continuously and update the UI when new issues are detected.
+
+### Query Tools
+
+r[mcp.query.search]
+The `tracey_search` tool MUST support keyword search across requirement text and IDs, returning matching requirements with their definitions and references.
+
+r[mcp.query.file-reqs]
+The `tracey_file_reqs` tool MUST return all requirements referenced in a specific source file, grouped by reference type (impl/verify).
+
+r[mcp.query.priority]
+The `tracey_priority` tool MUST suggest which uncovered requirements to implement next, prioritizing by section completeness and requirement dependencies.
+
+r[dashboard.query.search]
+The dashboard MUST provide a search interface for finding requirements by keyword in their text or ID.
+
+r[dashboard.query.file-reqs]
+The dashboard MUST show all requirements referenced by a specific file when viewing file details.


### PR DESCRIPTION
## Summary
- Bundles the official Tracey skill definition (`skill/SKILL.md` + `skill/references/tracey-spec.md`) in the repo, versioned alongside Tracey
- Adds `tracey skill install` CLI subcommand that writes the embedded skill files to `~/.claude/skills/tracey/` and `~/.codex/skills/tracey/`
- Supports `--claude` and `--codex` flags to target a single tool

## Details
- Skill files are embedded at compile time via `include_str!`
- Install is idempotent — safe to re-run, overwrites with latest version
- Reports destination paths on success
- Adds `dirs` crate for cross-platform home directory resolution

Fixes #59

## Test plan
- [x] `cargo check` passes
- [x] All 161 tests pass with `cargo nextest run`
- [x] `tracey skill install` installs to both Claude and Codex directories
- [x] `tracey skill install --claude` installs only to Claude
- [x] `tracey skill install --codex` installs only to Codex
- [x] Installed files match bundled source files
- [x] `tracey skill --help` and `tracey skill install --help` show correct usage