### PR TITLE
Show stale rule text diffs and enforce explicit stale guidance

### DIFF
--- a/crates/tracey/src/bridge/query.rs
+++ b/crates/tracey/src/bridge/query.rs
@@ -476,6 +476,7 @@ fn format_validation_result(result: &tracey_proto::ValidationResult) -> String {
             };
 
             if error.code == ValidationErrorCode::StaleRequirement {
+                // r[impl mcp.validation.stale.message-prefix]
                 output.push_str(&format!(
                     "  - {} [{:?}]{}\n",
                     error.message, error.code, location

--- a/crates/tracey/src/daemon/service.rs
+++ b/crates/tracey/src/daemon/service.rs
@@ -935,6 +935,7 @@ impl TraceyDaemon for TraceyService {
                                 ) {
                                     KnownRuleMatch::Exact => {}
                                     KnownRuleMatch::Stale(current_rule_id) => {
+                                        // r[impl validation.stale.message-prefix]
                                         let message = stale_requirement_message(
                                             project_root,
                                             &reference.req_id,
@@ -1399,6 +1400,9 @@ impl TraceyDaemon for TraceyService {
             match classify_reference_against_known_rules(&reference.req_id, known_for_prefix) {
                 KnownRuleMatch::Exact => {}
                 KnownRuleMatch::Stale(current_rule_id) => {
+                    // r[impl lsp.diagnostics.stale]
+                    // r[impl lsp.diagnostics.stale.message-prefix]
+                    // r[impl lsp.diagnostics.stale.diff]
                     let message = stale_requirement_message(
                         project_root,
                         &reference.req_id,
@@ -2375,6 +2379,7 @@ async fn load_previous_rule_text_from_git(
     source_file: &str,
     previous_rule_id: &RuleId,
 ) -> Option<HistoricalRuleText> {
+    // r[impl validation.stale.diff]
     let commits = run_git_capture(project_root, &["log", "--format=%H", "--", source_file])?;
 
     for commit in commits.lines() {
@@ -2492,6 +2497,7 @@ async fn stale_requirement_message(
     current_rule: Option<&ApiRule>,
     cache: &mut std::collections::HashMap<(RuleId, RuleId), Option<HistoricalRuleText>>,
 ) -> String {
+    // r[impl validation.stale.message-prefix]
     let mut message = String::from(STALE_IMPLEMENTATION_MUST_CHANGE_PREFIX);
 
     let Some(current_rule) = current_rule else {
@@ -2522,6 +2528,7 @@ async fn stale_requirement_message(
     };
 
     let Some(previous) = historical else {
+        // r[impl validation.stale.diff.fallback]
         message.push_str(
             "\n\nRule-text history is unavailable (git history is missing, shallow, or does not contain the older rule text).",
         );

--- a/docs/spec/tracey.md
+++ b/docs/spec/tracey.md
@@ -946,6 +946,15 @@ The system MUST identify requirements that are defined in specs but never refere
 r[validation.duplicates]
 The system MUST detect duplicate requirement IDs across all spec files.
 
+r[validation.stale.message-prefix]
+When reporting a stale requirement reference, the validation message MUST start with this exact sentence: `Implementation must be changed to match updated rule text — and ONLY ONCE THAT'S DONE must the code annotation be bumped`.
+
+r[validation.stale.diff]
+When reporting a stale requirement reference and source history is available, the validation message MUST include: previous rule text, current rule text, and a textual diff between them.
+
+r[validation.stale.diff.fallback]
+When reporting a stale requirement reference and source history is unavailable (for example, missing git metadata, shallow history, or no matching prior rule text), the validation message MUST include an explicit fallback note that rule-text history could not be retrieved.
+
 ## MCP Server
 
 The MCP server exposes tracey functionality as tools for AI assistants.
@@ -1062,6 +1071,9 @@ Large result sets SHOULD be paginated with hints showing how to retrieve more re
 
 r[mcp.validation.check]
 The `tracey_validate` tool MUST run all validation checks and return a report of issues found (broken refs, naming violations, circular deps, orphaned requirements, duplicates).
+
+r[mcp.validation.stale.message-prefix]
+When `tracey_validate` output includes stale-reference errors, each stale entry MUST begin with the stale-validation message text so the required message prefix is visible before any error code or formatting metadata.
 
 r[dashboard.query.search]
 The dashboard MUST provide a search interface for finding requirements by keyword in their text or ID.
@@ -1291,6 +1303,15 @@ The server MAY publish diagnostics for requirement definitions that have no impl
 
 r[lsp.diagnostics.impl-in-test]
 The server MUST publish diagnostics for `impl` annotations in files matched by `test_include` patterns, with severity `Error`. Test files should only contain `verify` annotations.
+
+r[lsp.diagnostics.stale]
+The server MUST publish diagnostics for stale requirement references, with severity `Warning`.
+
+> r[lsp.diagnostics.stale.message-prefix]
+> Stale-reference diagnostics MUST start with this exact sentence: `Implementation must be changed to match updated rule text — and ONLY ONCE THAT'S DONE must the code annotation be bumped`.
+
+> r[lsp.diagnostics.stale.diff]
+> When rule history is available, stale-reference diagnostics MUST include previous rule text, current rule text, and a textual diff between them. When unavailable, they MUST include an explicit fallback note.
 
 r[lsp.diagnostics.on-change]
 Diagnostics MUST be updated when files are modified, using debouncing to avoid excessive recomputation.


### PR DESCRIPTION
## Summary
Improve stale-rule diagnostics so they explicitly instruct implementers to change behavior before bumping annotations, and include rule-text history when available.

## Changes
- Added a shared stale-message builder used by both `validate` and LSP diagnostics.
- Enforced this exact message prefix at the start of stale diagnostics:
  - `Implementation must be changed to match updated rule text — and ONLY ONCE THAT'S DONE must the code annotation be bumped`
- For stale references, now attempts to load previous rule text from git history and includes:
  - Previous rule text
  - Current rule text
  - A line diff
  - Source commit hash for the previous rule text
- Added graceful fallback text when git history or prior rule text cannot be retrieved.
- Updated query/MCP text formatting so stale entries start with the stale message text instead of the enum tag.
- Added a unit test to verify stale output formatting starts with the required sentence.

## Test Plan
- `cargo nextest run -p tracey stale_validation_output_starts_with_message_text`
- `cargo nextest run -p tracey stale`

Closes #68
