### PR TITLE
Improve query output: caller-aware hints, stale rule counting, config summary

### DIFF
--- a/crates/tracey-api/src/lib.rs
+++ b/crates/tracey-api/src/lib.rs
@@ -90,6 +90,10 @@ pub struct ApiRule {
     pub impl_refs: Vec<ApiCodeRef>,
     pub verify_refs: Vec<ApiCodeRef>,
     pub depends_refs: Vec<ApiCodeRef>,
+    /// True if any reference to this rule is stale (points to an older version).
+    /// A stale rule is not counted as covered.
+    #[facet(default)]
+    pub is_stale: bool,
 }
 
 #[derive(Debug, Clone, Facet)]

--- a/crates/tracey-proto/src/lib.rs
+++ b/crates/tracey-proto/src/lib.rs
@@ -149,7 +149,11 @@ pub struct ImplStatus {
     pub spec: String,
     pub impl_name: String,
     pub total_rules: usize,
+    /// Rules with at least one exact implementation reference (not stale).
     pub covered_rules: usize,
+    /// Rules where any reference is stale (points to an older rule version).
+    /// Not included in covered_rules. covered_rules + stale_rules + uncovered = total.
+    pub stale_rules: usize,
     pub verified_rules: usize,
 }
 

--- a/crates/tracey/src/bridge/http/dashboard/src/api-types.ts
+++ b/crates/tracey/src/bridge/http/dashboard/src/api-types.ts
@@ -244,6 +244,11 @@ export interface ApiRule {
   implRefs: ApiCodeRef[];
   verifyRefs: ApiCodeRef[];
   dependsRefs: ApiCodeRef[];
+  /**
+   * True if any reference to this rule is stale (points to an older version).
+   * A stale rule is not counted as covered.
+   */
+  isStale?: boolean;
 }
 
 export interface ApiSpecForward {

--- a/crates/tracey/src/bridge/mcp.rs
+++ b/crates/tracey/src/bridge/mcp.rs
@@ -177,7 +177,7 @@ struct TraceyHandler {
 impl TraceyHandler {
     pub fn new(project_root: PathBuf) -> Self {
         Self {
-            client: query::QueryClient::new(project_root),
+            client: query::QueryClient::new(project_root, query::Caller::Mcp),
         }
     }
 }

--- a/crates/tracey/src/daemon/service.rs
+++ b/crates/tracey/src/daemon/service.rs
@@ -210,6 +210,7 @@ impl TraceyDaemon for TraceyService {
                     impl_name,
                     total_rules: s.total_rules,
                     covered_rules: s.impl_covered,
+                    stale_rules: s.stale_covered,
                     verified_rules: s.verify_covered,
                 })
                 .collect(),

--- a/crates/tracey/src/data.rs
+++ b/crates/tracey/src/data.rs
@@ -713,8 +713,6 @@ pub async fn build_dashboard_data_with_overlay(
             let mut api_rules = Vec::new();
             let mut stale_rule_ids: std::collections::HashSet<RuleId> =
                 std::collections::HashSet::new();
-            let mut exact_rule_ids: std::collections::HashSet<RuleId> =
-                std::collections::HashSet::new();
             for extracted in &extracted_rules {
                 let mut impl_refs = Vec::new();
                 let mut verify_refs = Vec::new();
@@ -749,11 +747,9 @@ pub async fn build_dashboard_data_with_overlay(
                             RuleIdMatch::Exact => match r.verb {
                                 RefVerb::Impl | RefVerb::Define => {
                                     impl_refs.push(code_ref);
-                                    exact_rule_ids.insert(rule_id.clone());
                                 }
                                 RefVerb::Verify => {
                                     verify_refs.push(code_ref);
-                                    exact_rule_ids.insert(rule_id.clone());
                                 }
                                 RefVerb::Depends | RefVerb::Related => depends_refs.push(code_ref),
                             },
@@ -794,6 +790,7 @@ pub async fn build_dashboard_data_with_overlay(
                     impl_refs,
                     verify_refs,
                     depends_refs,
+                    is_stale: false, // set in second pass below, after stale_rule_ids is complete
                 });
             }
 
@@ -808,15 +805,19 @@ pub async fn build_dashboard_data_with_overlay(
                 });
             }
 
+            // Annotate api_rules with is_stale (any stale ref taints the whole rule)
+            for rule in &mut api_rules {
+                rule.is_stale = stale_rule_ids.contains(&rule.id);
+            }
+
             // Build coverage map for this impl
             let mut coverage: BTreeMap<String, RuleCoverage> = BTreeMap::new();
             for rule in &api_rules {
                 let rule_id_string = rule.id.to_string();
                 let has_impl = !rule.impl_refs.is_empty();
                 let has_verify = !rule.verify_refs.is_empty();
-                let has_stale = stale_rule_ids.contains(&rule.id);
-                let has_exact = exact_rule_ids.contains(&rule.id);
-                let status = if has_stale && !has_exact {
+                let has_stale = rule.is_stale;
+                let status = if has_stale {
                     "stale"
                 } else if has_impl && has_verify {
                     "covered"

--- a/crates/tracey/src/main.rs
+++ b/crates/tracey/src/main.rs
@@ -311,7 +311,8 @@ async fn main() -> Result<()> {
         // r[impl daemon.cli.query]
         Command::Query { root, query } => {
             let project_root = root.unwrap_or_else(|| find_project_root().unwrap_or_default());
-            let query_client = bridge::query::QueryClient::new(project_root);
+            let query_client =
+                bridge::query::QueryClient::new(project_root, bridge::query::Caller::Cli);
             init_tracing(TracingConfig {
                 log_file: None,
                 enable_console: true,


### PR DESCRIPTION
## Summary

Improves the output of all `tracey query` subcommands and MCP tool responses in three areas: hint text is now tailored to whether the caller is the CLI or MCP server, stale rules are tracked as a separate bucket (never counted as covered), and the `status` output opens with a plain-English explanation of what spec and implementations are being analyzed.

## Changes

- Add `Caller` enum (`Cli` / `Mcp`) to `QueryClient`; a `hint()` helper emits the right syntax (`tracey query <cmd>` for CLI, `tracey_<tool>` for MCP) in every `---` footer.
- Add `stale_rules` to `ImplStatus` (proto) and `stale_covered` to `CoverageStats` (server). Stale rules are excluded from `covered_rules`; total = covered + stale + uncovered.
- Propagate `is_stale` onto `ApiRule` so the dashboard and coverage-map computation share the same staleness definition.
- Rewrite `status` output: prepend a config preamble listing the spec, its source, and the implementations being checked; replace terse percentage lines with natural-language sentences that call out stale and uncovered counts explicitly.
- Fix `data.rs`: remove the now-redundant `exact_rule_ids` set (staleness is determined solely by `stale_rule_ids`); set `is_stale` in a second pass after the set is fully populated.

## Testing

- `tracey query status` and `tracey query uncovered` produce caller-appropriate hint text.
- Stale rules no longer inflate `covered_rules` in `ImplStatus`.
- Coverage stats in the dashboard remain consistent with the new `is_stale` flag.