### PR TITLE
Fix query hints, status prose, and stale coverage buckets

### DIFF
--- a/crates/tracey-api/src/lib.rs
+++ b/crates/tracey-api/src/lib.rs
@@ -90,6 +90,8 @@ pub struct ApiRule {
     pub impl_refs: Vec<ApiCodeRef>,
     pub verify_refs: Vec<ApiCodeRef>,
     pub depends_refs: Vec<ApiCodeRef>,
+    #[facet(default)]
+    pub is_stale: bool,
 }
 
 #[derive(Debug, Clone, Facet)]

--- a/crates/tracey-proto/src/lib.rs
+++ b/crates/tracey-proto/src/lib.rs
@@ -14,7 +14,7 @@ pub use tracey_api::*;
 /// Protocol version — bump this whenever any RPC method is added, removed, or changed.
 /// The daemon writes this into its PID file; connectors compare it before connecting
 /// to detect stale daemons running an incompatible build.
-pub const PROTOCOL_VERSION: u32 = 1;
+pub const PROTOCOL_VERSION: u32 = 2;
 
 // ============================================================================
 // Request/Response types for the TraceyDaemon service
@@ -42,7 +42,7 @@ pub struct UncoveredResponse {
     pub spec: String,
     pub impl_name: String,
     pub total_rules: usize,
-    pub uncovered_count: usize,
+    pub missing_impl_count: usize,
     /// Rules grouped by section
     pub by_section: Vec<SectionRules>,
 }
@@ -82,7 +82,7 @@ pub struct UntestedResponse {
     pub spec: String,
     pub impl_name: String,
     pub total_rules: usize,
-    pub untested_count: usize,
+    pub missing_verify_count: usize,
     pub by_section: Vec<SectionRules>,
 }
 
@@ -149,8 +149,9 @@ pub struct ImplStatus {
     pub spec: String,
     pub impl_name: String,
     pub total_rules: usize,
-    pub covered_rules: usize,
-    pub verified_rules: usize,
+    pub impl_rules: usize,
+    pub verify_rules: usize,
+    pub stale_rules: usize,
 }
 
 /// Information about a specific rule

--- a/crates/tracey/src/bridge/http/dashboard/src/api-types.ts
+++ b/crates/tracey/src/bridge/http/dashboard/src/api-types.ts
@@ -244,6 +244,7 @@ export interface ApiRule {
   implRefs: ApiCodeRef[];
   verifyRefs: ApiCodeRef[];
   dependsRefs: ApiCodeRef[];
+  isStale?: boolean;
 }
 
 export interface ApiSpecForward {

--- a/crates/tracey/src/bridge/mcp.rs
+++ b/crates/tracey/src/bridge/mcp.rs
@@ -24,6 +24,7 @@ use rust_mcp_sdk::{McpServer, StdioTransport, ToMcpServerHandler, TransportOptio
 use serde::{Deserialize, Serialize};
 
 use crate::bridge::query;
+use crate::bridge::query::Caller;
 
 // ============================================================================
 // Tool Definitions (same as mcp.rs)
@@ -177,7 +178,7 @@ struct TraceyHandler {
 impl TraceyHandler {
     pub fn new(project_root: PathBuf) -> Self {
         Self {
-            client: query::QueryClient::new(project_root),
+            client: query::QueryClient::for_caller(project_root, Caller::Mcp),
         }
     }
 }

--- a/crates/tracey/src/daemon/service.rs
+++ b/crates/tracey/src/daemon/service.rs
@@ -209,8 +209,9 @@ impl TraceyDaemon for TraceyService {
                     spec,
                     impl_name,
                     total_rules: s.total_rules,
-                    covered_rules: s.impl_covered,
-                    verified_rules: s.verify_covered,
+                    impl_rules: s.impl_covered,
+                    verify_rules: s.verify_covered,
+                    stale_rules: s.stale_covered,
                 })
                 .collect(),
         }
@@ -230,7 +231,7 @@ impl TraceyDaemon for TraceyService {
                 spec: result.spec,
                 impl_name: result.impl_name,
                 total_rules: result.stats.total_rules,
-                uncovered_count: result.total_uncovered,
+                missing_impl_count: result.total_uncovered,
                 by_section: result
                     .by_section
                     .into_iter()
@@ -251,7 +252,7 @@ impl TraceyDaemon for TraceyService {
                 spec,
                 impl_name,
                 total_rules: 0,
-                uncovered_count: 0,
+                missing_impl_count: 0,
                 by_section: vec![],
             }
         }
@@ -270,7 +271,7 @@ impl TraceyDaemon for TraceyService {
                 spec: result.spec,
                 impl_name: result.impl_name,
                 total_rules: result.stats.total_rules,
-                untested_count: result.total_untested,
+                missing_verify_count: result.total_untested,
                 by_section: result
                     .by_section
                     .into_iter()
@@ -291,7 +292,7 @@ impl TraceyDaemon for TraceyService {
                 spec,
                 impl_name,
                 total_rules: 0,
-                untested_count: 0,
+                missing_verify_count: 0,
                 by_section: vec![],
             }
         }

--- a/crates/tracey/tests/integration_tests.rs
+++ b/crates/tracey/tests/integration_tests.rs
@@ -77,19 +77,22 @@ async fn test_status_coverage_percentages() {
     for impl_status in &status.impls {
         // Covered rules should not exceed total
         assert!(
-            impl_status.covered_rules <= impl_status.total_rules,
+            impl_status.impl_rules <= impl_status.total_rules,
             "Covered rules ({}) exceeds total ({})",
-            impl_status.covered_rules,
+            impl_status.impl_rules,
             impl_status.total_rules
         );
 
         // Verified rules should not exceed total
         assert!(
-            impl_status.verified_rules <= impl_status.total_rules,
+            impl_status.verify_rules <= impl_status.total_rules,
             "Verified rules ({}) exceeds total ({})",
-            impl_status.verified_rules,
+            impl_status.verify_rules,
             impl_status.total_rules
         );
+
+        // Stale rules should not exceed total.
+        assert!(impl_status.stale_rules <= impl_status.total_rules);
     }
 }
 
@@ -112,7 +115,7 @@ async fn test_uncovered_returns_rules() {
     assert_eq!(response.impl_name, "rust");
     // We have some uncovered rules (data.format, error.logging)
     assert!(
-        response.uncovered_count > 0,
+        response.missing_impl_count > 0,
         "Expected some uncovered rules"
     );
 }
@@ -154,7 +157,10 @@ async fn test_untested_returns_rules() {
     assert_eq!(response.spec, "test");
     assert_eq!(response.impl_name, "rust");
     // auth.session and auth.logout are implemented but not verified
-    assert!(response.untested_count > 0, "Expected some untested rules");
+    assert!(
+        response.missing_verify_count > 0,
+        "Expected some untested rules"
+    );
 }
 
 // ============================================================================

--- a/crates/tracey/tests/mcp_tests.rs
+++ b/crates/tracey/tests/mcp_tests.rs
@@ -67,7 +67,7 @@ async fn test_mcp_status_tool() {
     // Verify coverage metrics are reasonable
     let impl_status = test_impl.unwrap();
     assert!(impl_status.total_rules > 0);
-    assert!(impl_status.covered_rules <= impl_status.total_rules);
+    assert!(impl_status.impl_rules <= impl_status.total_rules);
 }
 
 // ============================================================================
@@ -89,7 +89,7 @@ async fn test_mcp_uncovered_tool_no_filter() {
     assert_eq!(response.spec, "test");
     assert_eq!(response.impl_name, "rust");
     // We have some uncovered rules in the fixture
-    assert!(response.uncovered_count > 0);
+    assert!(response.missing_impl_count > 0);
 }
 
 #[tokio::test]
@@ -152,7 +152,7 @@ async fn test_mcp_untested_tool() {
     assert_eq!(response.spec, "test");
     assert_eq!(response.impl_name, "rust");
     // Some rules are implemented but not tested
-    assert!(response.untested_count > 0);
+    assert!(response.missing_verify_count > 0);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- make query hints caller-aware (CLI vs MCP) so CLI shows `tracey query ...` commands
- expand `tracey query status` with plain-English config context and action-oriented guidance
- treat stale rules as a separate bucket and exclude them from covered counts
- rename ambiguous RPC fields for clarity (`impl_rules`, `verify_rules`, `missing_impl_count`, `missing_verify_count`) and bump protocol version

## Testing
- cargo fmt
- cargo nextest run
- cargo check -q

Fixes #77
