### PR TITLE
Add stale references query (tracey_stale / tracey query stale)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "6738d2e996274e499bc7b0d693c858b7720b9cd2543a0643a3087e6cb0a4fa16"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1290,7 +1290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1669,7 +1669,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 [[package]]
 name = "figue"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/figue?branch=main#8da0bfd32397ec88c40223ed4350ee44ed7b3662"
+source = "git+https://github.com/bearcove/figue?branch=main#96733218a3873d277095402cc9aa3b37d3820fa3"
 dependencies = [
  "ariadne",
  "camino",
@@ -1694,7 +1694,7 @@ dependencies = [
 [[package]]
 name = "figue-attrs"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/figue?branch=main#8da0bfd32397ec88c40223ed4350ee44ed7b3662"
+source = "git+https://github.com/bearcove/figue?branch=main#96733218a3873d277095402cc9aa3b37d3820fa3"
 dependencies = [
  "facet",
 ]
@@ -2315,7 +2315,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3503,7 +3503,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4031,7 +4031,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4810,7 +4810,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/tracey-api/src/lib.rs
+++ b/crates/tracey-api/src/lib.rs
@@ -94,12 +94,24 @@ pub struct ApiRule {
     /// A stale rule is not counted as covered.
     #[facet(default)]
     pub is_stale: bool,
+    /// Stale references pointing to older versions of this rule.
+    #[facet(default)]
+    pub stale_refs: Vec<ApiStaleRef>,
 }
 
 #[derive(Debug, Clone, Facet)]
 pub struct ApiCodeRef {
     pub file: String,
     pub line: usize,
+}
+
+/// A stale reference: code points to an older version of a rule.
+#[derive(Debug, Clone, Facet)]
+pub struct ApiStaleRef {
+    pub file: String,
+    pub line: usize,
+    /// The rule ID referenced in code (older version)
+    pub reference_id: RuleId,
 }
 
 /// Reverse traceability: file tree with coverage info

--- a/crates/tracey/src/bridge/http/dashboard/src/api-types.ts
+++ b/crates/tracey/src/bridge/http/dashboard/src/api-types.ts
@@ -253,6 +253,22 @@ export interface ApiRule {
    * A stale rule is not counted as covered.
    */
   isStale?: boolean;
+  /**
+   * Stale references pointing to older versions of this rule.
+   */
+  staleRefs?: ApiStaleRef[];
+}
+
+/**
+ * A stale reference: code points to an older version of a rule.
+ */
+export interface ApiStaleRef {
+  file: string;
+  line: number;
+  /**
+   * The rule ID referenced in code (older version)
+   */
+  reference_id: RuleId;
 }
 
 export interface ApiSpecForward {

--- a/crates/tracey/src/bridge/mcp.rs
+++ b/crates/tracey/src/bridge/mcp.rs
@@ -63,6 +63,19 @@ pub struct UntestedTool {
     pub prefix: Option<String>,
 }
 
+/// List stale references (code pointing to older rule versions)
+#[mcp_tool(
+    name = "tracey_stale",
+    description = "List references that point to older rule versions. These need code updates to match the current spec, then annotation bumps."
+)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct StaleTool {
+    #[serde(default)]
+    pub spec_impl: Option<String>,
+    #[serde(default)]
+    pub prefix: Option<String>,
+}
+
 /// Get code units without rule references
 #[mcp_tool(
     name = "tracey_unmapped",
@@ -155,6 +168,7 @@ tool_box!(
         StatusTool,
         UncoveredTool,
         UntestedTool,
+        StaleTool,
         UnmappedTool,
         RuleTool,
         ConfigTool,
@@ -214,6 +228,11 @@ impl ServerHandler for TraceyHandler {
                 let spec_impl = args.get("spec_impl").and_then(|v| v.as_str());
                 let prefix = args.get("prefix").and_then(|v| v.as_str());
                 self.client.untested(spec_impl, prefix).await
+            }
+            "tracey_stale" => {
+                let spec_impl = args.get("spec_impl").and_then(|v| v.as_str());
+                let prefix = args.get("prefix").and_then(|v| v.as_str());
+                self.client.stale(spec_impl, prefix).await
             }
             "tracey_unmapped" => {
                 let spec_impl = args.get("spec_impl").and_then(|v| v.as_str());

--- a/crates/tracey/src/main.rs
+++ b/crates/tracey/src/main.rs
@@ -210,6 +210,17 @@ enum QueryCommand {
         path: Option<String>,
     },
 
+    /// List stale references (code pointing to older rule versions)
+    Stale {
+        /// Spec/impl to query (e.g., "my-spec/rust"). Optional if only one exists.
+        #[facet(args::named, default)]
+        spec_impl: Option<String>,
+
+        /// Filter by rule ID prefix
+        #[facet(args::named, default)]
+        prefix: Option<String>,
+    },
+
     /// Show details about a specific rule
     Rule {
         /// Rule identifier to inspect
@@ -394,6 +405,11 @@ async fn main() -> Result<()> {
                 QueryCommand::Unmapped { spec_impl, path } => {
                     query_client
                         .unmapped(spec_impl.as_deref(), path.as_deref())
+                        .await
+                }
+                QueryCommand::Stale { spec_impl, prefix } => {
+                    query_client
+                        .stale(spec_impl.as_deref(), prefix.as_deref())
                         .await
                 }
                 QueryCommand::Rule { rule_id } => query_client.rule(&rule_id).await,


### PR DESCRIPTION
## Summary

Adds a dedicated query for listing stale references — code locations that point to older versions of spec rules. Previously, stale references were only surfaced through `tracey_validate`; this gives a first-class query with file:line details so users can locate and update annotations directly.

## Changes

- **tracey-api**: Added `ApiStaleRef` type and `stale_refs` field on `ApiRule`
- **tracey-proto**: Added `StaleRequest`, `StaleResponse`, `StaleEntry` types and `stale` RPC method on `TraceyDaemon` trait; bumped protocol version to 4
- **daemon/service**: Implemented `stale` RPC handler delegating to `QueryEngine::stale`
- **server (QueryEngine)**: Added `stale()` method that collects stale refs from forward data, filters by optional prefix, and sorts by file/line
- **data**: Populated `stale_refs` on `ApiRule` during dashboard data build when references are detected as stale
- **bridge/query**: Added `stale()` query client method with formatted output (grouped by file, with hints)
- **bridge/mcp**: Added `tracey_stale` MCP tool with `spec_impl` and `prefix` parameters
- **main**: Added `Stale` CLI subcommand under `tracey query stale`
- **dashboard api-types.ts**: Added corresponding TypeScript types
- Updated status hint to point to `tracey_stale` instead of `tracey_validate` for stale references

## Test plan

- [ ] Run `tracey query stale` against a repo with stale annotations and verify file:line output
- [ ] Run `tracey query stale --prefix <prefix>` and verify filtering works
- [ ] Verify `tracey query status` now hints at `tracey_stale` when stale rules exist
- [ ] Verify MCP tool `tracey_stale` works via `tracey mcp`
- [ ] Verify daemon protocol version bump causes stale daemon detection on upgrade