### PR TITLE
Use marq AST-level diffing for hover diffs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,7 +1228,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1250,7 +1250,7 @@ checksum = "6738d2e996274e499bc7b0d693c858b7720b9cd2543a0643a3087e6cb0a4fa16"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1290,7 +1290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1327,7 +1327,7 @@ dependencies = [
 [[package]]
 name = "facet"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#3d9442a35a7b32478214bfd7d4aeb04918e049c2"
+source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
 dependencies = [
  "autocfg",
  "facet-core",
@@ -1361,7 +1361,7 @@ dependencies = [
 [[package]]
 name = "facet-core"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#3d9442a35a7b32478214bfd7d4aeb04918e049c2"
+source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
 dependencies = [
  "autocfg",
  "camino",
@@ -1374,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "facet-dessert"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#3d9442a35a7b32478214bfd7d4aeb04918e049c2"
+source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
 dependencies = [
  "facet-core",
  "facet-reflect",
@@ -1404,7 +1404,7 @@ dependencies = [
 [[package]]
 name = "facet-format"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#3d9442a35a7b32478214bfd7d4aeb04918e049c2"
+source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
 dependencies = [
  "facet-core",
  "facet-dessert",
@@ -1432,7 +1432,7 @@ dependencies = [
 [[package]]
 name = "facet-macro-parse"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#3d9442a35a7b32478214bfd7d4aeb04918e049c2"
+source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
 dependencies = [
  "facet-macro-types",
  "proc-macro2",
@@ -1442,7 +1442,7 @@ dependencies = [
 [[package]]
 name = "facet-macro-types"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#3d9442a35a7b32478214bfd7d4aeb04918e049c2"
+source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1452,7 +1452,7 @@ dependencies = [
 [[package]]
 name = "facet-macros"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#3d9442a35a7b32478214bfd7d4aeb04918e049c2"
+source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
 dependencies = [
  "facet-macros-impl",
 ]
@@ -1460,7 +1460,7 @@ dependencies = [
 [[package]]
 name = "facet-macros-impl"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#3d9442a35a7b32478214bfd7d4aeb04918e049c2"
+source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
 dependencies = [
  "facet-macro-parse",
  "facet-macro-types",
@@ -1473,7 +1473,7 @@ dependencies = [
 [[package]]
 name = "facet-path"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#3d9442a35a7b32478214bfd7d4aeb04918e049c2"
+source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
 dependencies = [
  "facet-core",
 ]
@@ -1505,7 +1505,7 @@ dependencies = [
 [[package]]
 name = "facet-reflect"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#3d9442a35a7b32478214bfd7d4aeb04918e049c2"
+source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
 dependencies = [
  "facet-core",
  "facet-path",
@@ -1522,7 +1522,7 @@ source = "git+https://github.com/facet-rs/facet-xml?branch=main#a10a535c67269d86
 [[package]]
 name = "facet-solver"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#3d9442a35a7b32478214bfd7d4aeb04918e049c2"
+source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
 dependencies = [
  "facet-core",
  "facet-reflect",
@@ -1577,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "facet-toml"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#3d9442a35a7b32478214bfd7d4aeb04918e049c2"
+source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
 dependencies = [
  "facet-core",
  "facet-format",
@@ -1610,7 +1610,7 @@ dependencies = [
 [[package]]
 name = "facet-value"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#3d9442a35a7b32478214bfd7d4aeb04918e049c2"
+source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
 dependencies = [
  "facet-core",
  "facet-format",
@@ -1633,7 +1633,7 @@ dependencies = [
 [[package]]
 name = "facet-yaml"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#3d9442a35a7b32478214bfd7d4aeb04918e049c2"
+source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
 dependencies = [
  "facet",
  "facet-core",
@@ -2315,7 +2315,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2507,7 +2507,7 @@ dependencies = [
 [[package]]
 name = "marq"
 version = "0.1.0"
-source = "git+https://github.com/bearcove/marq?branch=ast-diff-api#a3d70b27fb66e98d6a12962335795525a5c7a5e7"
+source = "git+https://github.com/bearcove/marq?branch=main#bea7207e2dfa61d53612f7fd9716a73cceaa1376"
 dependencies = [
  "aasvg",
  "arborium",
@@ -2758,7 +2758,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3490,7 +3490,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3503,7 +3503,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4031,7 +4031,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4810,7 +4810,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4830,15 +4830,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ notify = "8"
 tantivy = "0.22"
 
 # Markdown processing (with syntax highlighting and diagram handlers)
-marq = { git = "https://github.com/bearcove/marq", branch = "ast-diff-api", features = ["all-handlers"] }
+marq = { git = "https://github.com/bearcove/marq", branch = "main", features = ["all-handlers"] }
 
 # The profile that 'dist' will build with
 [profile.dist]


### PR DESCRIPTION
## Summary
- Replace local word-level LCS diff with `marq::diff_markdown_inline` which preserves markdown structure (blockquote markers, code blocks, paragraph breaks) through the diff
- Delete ~90 lines of local diffing code (`WordDiffOp`, `word_diff`, `build_markdown_word_diff`)
- Point marq dependency at [bearcove/marq#9](https://github.com/bearcove/marq/pull/9) (`ast-diff-api` branch)

Closes #86

Depends on [bearcove/marq#9](https://github.com/bearcove/marq/pull/9) — once that merges, update the marq dependency back to `branch = "main"`.

## Test plan
- [x] `cargo build` clean
- [x] `cargo clippy` clean
- [x] All 180 tests pass
- [ ] Manual: verify hover diffs on versioned/stale rules preserve blockquote structure