### PR TITLE
Fix workspace symbol links to use real spec file paths

### DIFF
--- a/crates/tracey-proto/src/lib.rs
+++ b/crates/tracey-proto/src/lib.rs
@@ -477,6 +477,9 @@ pub struct LspSymbol {
     pub name: String,
     /// Kind: "definition", "impl", "verify", etc.
     pub kind: String,
+    /// Source file path for the symbol, relative to project root when available
+    #[facet(default)]
+    pub path: Option<String>,
     /// Range
     pub start_line: u32,
     pub start_char: u32,

--- a/crates/tracey/src/daemon/service.rs
+++ b/crates/tracey/src/daemon/service.rs
@@ -1430,6 +1430,7 @@ impl TraceyDaemon for TraceyService {
                         symbols.push(LspSymbol {
                             name: rule.id.to_string(),
                             kind: "requirement".to_string(),
+                            path: rule.source_file.clone(),
                             start_line: line,
                             start_char: col,
                             end_line: line,
@@ -1447,6 +1448,7 @@ impl TraceyDaemon for TraceyService {
                 symbols.push(LspSymbol {
                     name: r.req_id.to_string(),
                     kind: format!("{:?}", r.verb).to_lowercase(),
+                    path: None,
                     start_line,
                     start_char,
                     end_line,
@@ -1481,6 +1483,7 @@ impl TraceyDaemon for TraceyService {
                     symbols.push(LspSymbol {
                         name: rule.id.to_string(),
                         kind: "requirement".to_string(),
+                        path: rule.source_file.clone(),
                         start_line: line,
                         start_char: char,
                         end_line: line,

--- a/crates/tracey/tests/integration_tests.rs
+++ b/crates/tracey/tests/integration_tests.rs
@@ -486,6 +486,14 @@ async fn test_lsp_workspace_symbols() {
             "Symbol {} doesn't match query 'auth'",
             symbol.name
         );
+        let path = symbol
+            .path
+            .as_deref()
+            .expect("workspace symbols should include source file path");
+        assert!(
+            path.ends_with(".md"),
+            "Expected workspace symbol path to point to markdown spec file, got: {path}"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
Workspace symbol locations were pointing to a hardcoded  directory path, which produced broken/non-file links in editors.

This change carries the originating spec source file through  and uses it to construct symbol URIs.

## Changes
- Added optional  field to  in 
- Populated symbol paths from rule  in daemon symbol generation
- Updated LSP bridge  URI construction to resolve real file paths (relative or absolute)
- Added regression tests for symbol URI resolution and workspace symbol path presence

## Testing
- 
- 

Fixes #110