### PR TITLE
Add tracey ai setup command for MCP + skill install

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,16 @@ Full language server with:
 
 Install the [Zed extension](tracey-zed/) or point any LSP-compatible editor at `tracey lsp`.
 
+### AI Setup (`tracey ai`)
+
+Set up AI assistants in one command:
+
+```bash
+tracey ai           # register MCP + install skill for codex/claude
+tracey ai --codex   # codex only
+tracey ai --claude  # claude only
+```
+
 ### MCP Server (`tracey mcp`)
 
 Exposes tracey as an [MCP](https://modelcontextprotocol.io/) tool server for AI assistants. Tools include `tracey_status`, `tracey_uncovered`, `tracey_untested`, `tracey_stale`, `tracey_unmapped`, `tracey_rule`, `tracey_config`, `tracey_validate`, and more.
@@ -182,7 +192,7 @@ tracey query validate            # check for broken refs, naming issues
 
 ### AI Skill (`tracey skill install`)
 
-Bundled skill for Claude Code and Codex that teaches the AI how to add correct tracey annotations:
+Bundled skill for Claude Code and Codex that teaches the AI how to add correct tracey annotations. Use this when you want to install or refresh the skill without touching MCP registration:
 
 ```bash
 tracey skill install --claude    # install to ~/.claude/skills/tracey

--- a/README.md.in
+++ b/README.md.in
@@ -162,6 +162,16 @@ Full language server with:
 
 Install the [Zed extension](tracey-zed/) or point any LSP-compatible editor at `tracey lsp`.
 
+### AI Setup (`tracey ai`)
+
+Set up AI assistants in one command:
+
+```bash
+tracey ai           # register MCP + install skill for codex/claude
+tracey ai --codex   # codex only
+tracey ai --claude  # claude only
+```
+
 ### MCP Server (`tracey mcp`)
 
 Exposes tracey as an [MCP](https://modelcontextprotocol.io/) tool server for AI assistants. Tools include `tracey_status`, `tracey_uncovered`, `tracey_untested`, `tracey_stale`, `tracey_unmapped`, `tracey_rule`, `tracey_config`, `tracey_validate`, and more.
@@ -182,7 +192,7 @@ tracey query validate            # check for broken refs, naming issues
 
 ### AI Skill (`tracey skill install`)
 
-Bundled skill for Claude Code and Codex that teaches the AI how to add correct tracey annotations:
+Bundled skill for Claude Code and Codex that teaches the AI how to add correct tracey annotations. Use this when you want to install or refresh the skill without touching MCP registration:
 
 ```bash
 tracey skill install --claude    # install to ~/.claude/skills/tracey

--- a/docs/content/guide/ai-integration.md
+++ b/docs/content/guide/ai-integration.md
@@ -10,17 +10,22 @@ Tracey exposes its coverage analysis as MCP (Model Context Protocol) tools, lett
 Register tracey with supported MCP clients:
 
 ```bash
-tracey mcp register
+tracey ai
 ```
 
-This checks your `PATH`, then runs MCP registration for whichever clients are installed (`codex` and/or `claude`). It prints each command before executing it.
+This checks your `PATH`, prompts before running each MCP registration command, and installs the bundled Tracey skill for the selected clients.
 
 Use `--codex` or `--claude` to target only one:
 
 ```bash
-tracey mcp register --codex
-tracey mcp register --claude
+tracey ai --codex
+tracey ai --claude
 ```
+
+Manual commands are still available:
+
+- `tracey mcp register` - register MCP only
+- `tracey skill install` - install/reinstall the bundled skill only
 
 ## Available tools
 

--- a/docs/content/guide/cli-reference.md
+++ b/docs/content/guide/cli-reference.md
@@ -45,13 +45,23 @@ Communicates over stdio. See [AI Integration](ai-integration.md) for setup.
 
 ### `tracey mcp register`
 
-Register tracey as an MCP server in supported AI CLIs.
+Register tracey as an MCP server in supported AI CLIs (MCP only).
 
 ```
 tracey mcp register [--codex] [--claude]
 ```
 
 If no flags are provided, tracey attempts both clients and skips any executable that is not in `PATH`.
+
+### `tracey ai`
+
+Register MCP and install the bundled Tracey skill for supported AI CLIs.
+
+```
+tracey ai [--codex] [--claude]
+```
+
+If no flags are provided, tracey targets both clients. Use this as the default AI setup command.
 
 ## Daemon management
 
@@ -202,7 +212,7 @@ See [Versioning](versioning.md) for the full workflow.
 
 ### `tracey skill install`
 
-Install the bundled Tracey skill for AI assistants.
+Install or reinstall the bundled Tracey skill for AI assistants.
 
 ```
 tracey skill install [--claude] [--codex]

--- a/docs/content/guide/getting-started.md
+++ b/docs/content/guide/getting-started.md
@@ -19,6 +19,16 @@ Or build from source:
 cargo install --locked --git https://github.com/bearcove/tracey --branch main tracey
 ```
 
+## Optional: set up AI assistants
+
+If you use Codex CLI and/or Claude Code, run:
+
+```bash
+tracey ai
+```
+
+This registers tracey as an MCP server and installs the bundled Tracey skill.
+
 ## Create your spec
 
 Create a markdown file with your requirements. Each requirement uses the syntax `r[requirement.id]` followed by its text:

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -11,7 +11,7 @@ Add proper spec annotations to code using Tracey's requirement tracking system.
 
 Tracey maintains traceability between specification requirements and code. This skill helps add proper `r[impl req.id]` and `r[verify req.id]` annotations to code, find which requirements need implementation or testing, and understand Tracey annotation syntax.
 
-**Primary Interface:** Use Tracey MCP tools (`tracey_status`, `tracey_uncovered`, `tracey_untested`, `tracey_rule`, `tracey_unmapped`) to discover requirements and validate coverage. The MCP tools provide self-documenting output showing which prefixes to use and what requirements need work.
+**Primary Interface:** Use Tracey MCP tools (`tracey_status`, `tracey_uncovered`, `tracey_untested`, `tracey_stale`, `tracey_rule`, `tracey_unmapped`, `tracey_validate`, `tracey_config`) to discover requirements and validate coverage. The MCP tools provide self-documenting output showing which prefixes to use and what requirements need work.
 
 ## When to Use
 
@@ -29,8 +29,11 @@ Use this skill when:
 | `tracey_status` | See configured specs, prefixes, and coverage percentages |
 | `tracey_uncovered` | List requirements without implementation |
 | `tracey_untested` | List requirements without verification/tests |
+| `tracey_stale` | List references that point to older requirement versions |
 | `tracey_unmapped` | Show code that lacks requirement references |
 | `tracey_rule <id>` | Get full details about a specific requirement |
+| `tracey_validate` | Validate references and naming for a spec/impl |
+| `tracey_config` | Display configured specs, impls, include/exclude globs |
 
 **Tip:** Start with `tracey_status` to see what prefix to use (e.g., `r[...]` vs `shm[...]`), then use `tracey_uncovered` or `tracey_untested` to find work that needs doing.
 


### PR DESCRIPTION
## Summary
- add a new `tracey ai` command that configures AI assistants end-to-end (MCP registration + bundled skill install)
- refactor MCP registration and skill install logic to share client-target selection (`--codex` / `--claude`)
- keep `tracey mcp register` and `tracey skill install` as focused/manual commands, and point users to `tracey ai`
- upgrade the bundled Tracey skill quick reference to include the broader current MCP toolset
- update docs and README to present `tracey ai` as the default AI setup flow

## Testing
- `cargo fmt`
- `cargo check`
- `cargo nextest run -p tracey`
- `cargo run -p tracey -- ai --help`

Closes #126
