### PR TITLE
Fix spec outline ordering fallback to file path

### DIFF
--- a/crates/tracey/src/data.rs
+++ b/crates/tracey/src/data.rs
@@ -2456,8 +2456,10 @@ async fn load_spec_content(
         }
     }
 
-    // Sort by weight
-    files.sort_by_key(|(_, _, weight)| *weight);
+    // Sort by weight first, then lexicographically by path for deterministic order.
+    files.sort_by(|(path_a, _, weight_a), (path_b, _, weight_b)| {
+        weight_a.cmp(weight_b).then_with(|| path_a.cmp(path_b))
+    });
 
     // Concatenate all markdown files to render as one document
     // This ensures heading IDs are hierarchical across all files


### PR DESCRIPTION
## Summary
Spec file ordering for rendered outline content now uses explicit frontmatter weight first, with deterministic lexicographical path ordering as the fallback for equal weights.

## Changes
- sort spec files by `(weight, relative_path)` during spec content loading
- add integration coverage for weighted ordering and lexicographical fallback

## Testing
- cargo check -p tracey
- cargo nextest run -p tracey -E 'binary(integration_tests) & test(test_spec_content_orders_files_by_weight_then_path)'

Fixes #131
