### PR TITLE
bumped marq to latest commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,7 +1346,7 @@ checksum = "6738d2e996274e499bc7b0d693c858b7720b9cd2543a0643a3087e6cb0a4fa16"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1386,7 +1386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1423,7 +1423,7 @@ dependencies = [
 [[package]]
 name = "facet"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
+source = "git+https://github.com/facet-rs/facet?branch=main#5dfc3397d6e6cc08e4fd9f86215e5200674b40b3"
 dependencies = [
  "autocfg",
  "facet-core",
@@ -1457,7 +1457,7 @@ dependencies = [
 [[package]]
 name = "facet-core"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
+source = "git+https://github.com/facet-rs/facet?branch=main#5dfc3397d6e6cc08e4fd9f86215e5200674b40b3"
 dependencies = [
  "autocfg",
  "camino",
@@ -1470,7 +1470,7 @@ dependencies = [
 [[package]]
 name = "facet-dessert"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
+source = "git+https://github.com/facet-rs/facet?branch=main#5dfc3397d6e6cc08e4fd9f86215e5200674b40b3"
 dependencies = [
  "facet-core",
  "facet-reflect",
@@ -1500,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "facet-format"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
+source = "git+https://github.com/facet-rs/facet?branch=main#5dfc3397d6e6cc08e4fd9f86215e5200674b40b3"
 dependencies = [
  "facet-core",
  "facet-dessert",
@@ -1528,7 +1528,7 @@ dependencies = [
 [[package]]
 name = "facet-macro-parse"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
+source = "git+https://github.com/facet-rs/facet?branch=main#5dfc3397d6e6cc08e4fd9f86215e5200674b40b3"
 dependencies = [
  "facet-macro-types",
  "proc-macro2",
@@ -1538,7 +1538,7 @@ dependencies = [
 [[package]]
 name = "facet-macro-types"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
+source = "git+https://github.com/facet-rs/facet?branch=main#5dfc3397d6e6cc08e4fd9f86215e5200674b40b3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1548,7 +1548,7 @@ dependencies = [
 [[package]]
 name = "facet-macros"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
+source = "git+https://github.com/facet-rs/facet?branch=main#5dfc3397d6e6cc08e4fd9f86215e5200674b40b3"
 dependencies = [
  "facet-macros-impl",
 ]
@@ -1556,7 +1556,7 @@ dependencies = [
 [[package]]
 name = "facet-macros-impl"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
+source = "git+https://github.com/facet-rs/facet?branch=main#5dfc3397d6e6cc08e4fd9f86215e5200674b40b3"
 dependencies = [
  "facet-macro-parse",
  "facet-macro-types",
@@ -1569,7 +1569,7 @@ dependencies = [
 [[package]]
 name = "facet-path"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
+source = "git+https://github.com/facet-rs/facet?branch=main#5dfc3397d6e6cc08e4fd9f86215e5200674b40b3"
 dependencies = [
  "facet-core",
 ]
@@ -1601,7 +1601,7 @@ dependencies = [
 [[package]]
 name = "facet-reflect"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
+source = "git+https://github.com/facet-rs/facet?branch=main#5dfc3397d6e6cc08e4fd9f86215e5200674b40b3"
 dependencies = [
  "facet-core",
  "facet-path",
@@ -1618,7 +1618,7 @@ source = "git+https://github.com/facet-rs/facet-xml?branch=main#a10a535c67269d86
 [[package]]
 name = "facet-solver"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
+source = "git+https://github.com/facet-rs/facet?branch=main#5dfc3397d6e6cc08e4fd9f86215e5200674b40b3"
 dependencies = [
  "facet-core",
  "facet-reflect",
@@ -1673,7 +1673,7 @@ dependencies = [
 [[package]]
 name = "facet-toml"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
+source = "git+https://github.com/facet-rs/facet?branch=main#5dfc3397d6e6cc08e4fd9f86215e5200674b40b3"
 dependencies = [
  "facet-core",
  "facet-format",
@@ -1706,7 +1706,7 @@ dependencies = [
 [[package]]
 name = "facet-value"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
+source = "git+https://github.com/facet-rs/facet?branch=main#5dfc3397d6e6cc08e4fd9f86215e5200674b40b3"
 dependencies = [
  "facet-core",
  "facet-format",
@@ -1729,7 +1729,7 @@ dependencies = [
 [[package]]
 name = "facet-yaml"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#68ddedfb9999dcf53079f2eb35416f6b21b87f04"
+source = "git+https://github.com/facet-rs/facet?branch=main#5dfc3397d6e6cc08e4fd9f86215e5200674b40b3"
 dependencies = [
  "facet",
  "facet-core",
@@ -2411,7 +2411,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2603,7 +2603,7 @@ dependencies = [
 [[package]]
 name = "marq"
 version = "0.1.0"
-source = "git+https://github.com/bearcove/marq?branch=main#5ad5b4af244c179242c5457220e1e264e4fad04a"
+source = "git+https://github.com/bearcove/marq?branch=main#0de213cca92cdaddcb4d4fbfd0d4e30f2016fa04"
 dependencies = [
  "aasvg",
  "arborium",
@@ -3599,7 +3599,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4127,7 +4127,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4928,7 +4928,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]


### PR DESCRIPTION
Bump `marq` dependency to the latest commit on the main branch of bearcove/marq. Closes #138.