### PR TITLE
Reduce unknown-prefix false positives in LSP diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Tracey uses lightweight annotations in markdown and source code comments to link
 - Analyzing impact when requirements or code changes
 - Detecting stale references when spec text changes but code annotations haven't been updated
 
-For the full specification, see [docs/content/spec/tracey.md](docs/content/spec/tracey.md).
+For the full specification, see [docs/spec/tracey.md](docs/spec/tracey.md).
 
 ## Installation
 

--- a/crates/tracey/src/daemon/service.rs
+++ b/crates/tracey/src/daemon/service.rs
@@ -1384,6 +1384,14 @@ impl TraceyDaemon for TraceyService {
 
             // Check for unknown prefix
             if !known_prefixes.contains(reference.prefix.as_str()) {
+                if !source_reference_uses_explicit_verb(
+                    &req.content,
+                    reference.span.offset,
+                    reference.span.length,
+                    &reference.prefix,
+                ) {
+                    continue;
+                }
                 debug!(
                     "lsp_diagnostics unknown-prefix path={} ref_prefix={} ref_id={} known_prefixes={:?}",
                     path.display(),
@@ -1392,7 +1400,7 @@ impl TraceyDaemon for TraceyService {
                     known_prefixes
                 );
                 diagnostics.push(LspDiagnostic {
-                    severity: "error".to_string(),
+                    severity: "hint".to_string(),
                     code: "unknown-prefix".to_string(),
                     message: format!("Unknown prefix: '{}'", reference.prefix),
                     start_line,
@@ -2293,6 +2301,26 @@ fn extract_markdown_rule_references(content: &str) -> Vec<MarkdownRuleReference>
     }
 
     out
+}
+
+fn source_reference_uses_explicit_verb(
+    content: &str,
+    offset: usize,
+    length: usize,
+    prefix: &str,
+) -> bool {
+    let end = offset.saturating_add(length);
+    let Some(span_text) = content.get(offset..end) else {
+        return true;
+    };
+    let Some(inner) = span_text
+        .strip_prefix(prefix)
+        .and_then(|s| s.strip_prefix('['))
+        .and_then(|s| s.strip_suffix(']'))
+    else {
+        return true;
+    };
+    inner.contains(' ')
 }
 
 /// Look up build-data reqs for a source file path.

--- a/crates/tracey/src/data.rs
+++ b/crates/tracey/src/data.rs
@@ -1612,6 +1612,26 @@ fn compute_validation_by_impl(
     out
 }
 
+fn source_reference_uses_explicit_verb(
+    content: &str,
+    offset: usize,
+    length: usize,
+    prefix: &str,
+) -> bool {
+    let end = offset.saturating_add(length);
+    let Some(span_text) = content.get(offset..end) else {
+        return true;
+    };
+    let Some(inner) = span_text
+        .strip_prefix(prefix)
+        .and_then(|s| s.strip_prefix('['))
+        .and_then(|s| s.strip_suffix(']'))
+    else {
+        return true;
+    };
+    inner.contains(' ')
+}
+
 fn compute_workspace_diagnostics(
     abs_root: &Path,
     config: &ApiConfig,
@@ -1657,8 +1677,16 @@ fn compute_workspace_diagnostics(
                 span_to_range(content, reference.span.offset, reference.span.length);
 
             if !known_prefixes.contains(reference.prefix.as_str()) {
+                if !source_reference_uses_explicit_verb(
+                    content,
+                    reference.span.offset,
+                    reference.span.length,
+                    &reference.prefix,
+                ) {
+                    continue;
+                }
                 diagnostics.push(LspDiagnostic {
-                    severity: "error".to_string(),
+                    severity: "hint".to_string(),
                     code: "unknown-prefix".to_string(),
                     message: format!("Unknown prefix: '{}'", reference.prefix),
                     start_line,

--- a/crates/tracey/tests/lsp_diagnostic_lifecycle_tests.rs
+++ b/crates/tracey/tests/lsp_diagnostic_lifecycle_tests.rs
@@ -718,6 +718,35 @@ async fn test_unknown_prefix_diagnostic() {
     );
 }
 
+/// Test that short-form prose like `chunk[i]` does not trigger unknown-prefix diagnostics.
+#[tokio::test]
+async fn test_unknown_prefix_ignored_for_short_form_prose() {
+    let (temp, service) = create_isolated_test_service().await;
+    let test_file = temp.path().join("src/prose.rs");
+    let content = "/// chunk[i] immediately follows.\nfn prose() {}\n";
+    std::fs::write(&test_file, content).expect("Failed to write prose file");
+
+    rpc(service
+        .client
+        .vfs_open(test_file.display().to_string(), content.to_string())
+        .await);
+
+    let diagnostics = rpc(service
+        .client
+        .lsp_diagnostics(LspDocumentRequest {
+            path: test_file.display().to_string(),
+            content: content.to_string(),
+        })
+        .await);
+
+    let unknown_prefix = diagnostics.iter().find(|d| d.code == "unknown-prefix");
+    assert!(
+        unknown_prefix.is_none(),
+        "Expected no unknown-prefix diagnostic for short-form prose chunk[i], got: {:?}",
+        diagnostics
+    );
+}
+
 // ============================================================================
 // LSP Bridge Behavior Simulation Tests
 // ============================================================================


### PR DESCRIPTION
## Summary
Adjust LSP/workspace diagnostics so unknown-prefix is less noisy in prose comments without breaking short-form annotation support.

## Changes
- Ignore unknown-prefix diagnostics for short-form references (`prefix[req.id]`) and only report unknown-prefix for explicit verb form (`prefix[verb req.id]`).
- Downgrade unknown-prefix severity from `error` to `hint`.
- Add regression test for `chunk[i]` prose not producing unknown-prefix.

## Testing
- `cargo nextest run -p tracey --test lsp_diagnostic_lifecycle_tests`
