### PR TITLE
Fix dashboard dist for crates.io publishing

### DIFF
--- a/crates/tracey/build.rs
+++ b/crates/tracey/build.rs
@@ -166,29 +166,49 @@ fn generate_typescript_types() {
     }
 }
 
+fn copy_dir_recursive(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).expect("Failed to create directory");
+    for entry in fs::read_dir(src).expect("Failed to read directory") {
+        let entry = entry.expect("Failed to read entry");
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        // Skip node_modules and dist — those belong in OUT_DIR only
+        if name_str == "node_modules" || name_str == "dist" {
+            continue;
+        }
+        let src_path = entry.path();
+        let dst_path = dst.join(&name);
+        if src_path.is_dir() {
+            copy_dir_recursive(&src_path, &dst_path);
+        } else {
+            fs::copy(&src_path, &dst_path).expect("Failed to copy file");
+        }
+    }
+}
+
 fn build_dashboard() {
-    // Dashboard is colocated with the HTTP bridge
-    let dashboard_dir = Path::new("src/bridge/http/dashboard");
-    let dist_dir = dashboard_dir.join("dist");
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let dashboard_src = Path::new("src/bridge/http/dashboard");
+    let dashboard_out = Path::new(&out_dir).join("dashboard");
+    let dist_dir = dashboard_out.join("dist");
 
     // Re-run if dashboard source changes
     println!("cargo:rerun-if-changed=src/bridge/http/dashboard/src");
     println!("cargo:rerun-if-changed=src/bridge/http/dashboard/index.html");
     println!("cargo:rerun-if-changed=src/bridge/http/dashboard/package.json");
     println!("cargo:rerun-if-changed=src/bridge/http/dashboard/vite.config.ts");
-    // Re-run if output is missing (so deleting dist triggers rebuild)
-    println!("cargo:rerun-if-changed=src/bridge/http/dashboard/dist/index.html");
-    println!("cargo:rerun-if-changed=src/bridge/http/dashboard/dist/assets/index.js");
-    println!("cargo:rerun-if-changed=src/bridge/http/dashboard/dist/assets/index.css");
 
-    // Skip build if dist already exists (for faster incremental builds)
-    // To force rebuild, delete the dist directory
+    // Skip build if dist already exists in OUT_DIR (for faster incremental builds)
     if dist_dir.join("index.html").exists()
         && dist_dir.join("assets/index.js").exists()
         && dist_dir.join("assets/index.css").exists()
     {
         return;
     }
+
+    // Copy dashboard source into OUT_DIR so pnpm/vite run entirely outside the source tree
+    copy_dir_recursive(dashboard_src, &dashboard_out);
+    let dashboard_dir = &dashboard_out;
 
     // Check if node is available
     let node_check = shell_command("node").arg("--version").output();
@@ -312,7 +332,7 @@ fn build_dashboard() {
         panic!("pnpm install failed");
     }
 
-    // Build the dashboard
+    // Build the dashboard (output goes to OUT_DIR/dashboard/dist)
     let status = shell_command("pnpm")
         .args(["run", "build"])
         .current_dir(dashboard_dir)

--- a/crates/tracey/src/bridge/http/mod.rs
+++ b/crates/tracey/src/bridge/http/mod.rs
@@ -198,10 +198,10 @@ pub async fn run(
     Ok(())
 }
 
-// Embedded dashboard assets (colocated in src/bridge/http/dashboard/)
-static INDEX_HTML: &str = include_str!("dashboard/dist/index.html");
-static INDEX_CSS: &str = include_str!("dashboard/dist/assets/index.css");
-static INDEX_JS: &str = include_str!("dashboard/dist/assets/index.js");
+// Embedded dashboard assets (built into OUT_DIR by build.rs)
+static INDEX_HTML: &str = include_str!(concat!(env!("OUT_DIR"), "/dashboard/dist/index.html"));
+static INDEX_CSS: &str = include_str!(concat!(env!("OUT_DIR"), "/dashboard/dist/assets/index.css"));
+static INDEX_JS: &str = include_str!(concat!(env!("OUT_DIR"), "/dashboard/dist/assets/index.js"));
 
 /// SPA fallback - serve index.html for all non-API routes.
 async fn spa_fallback() -> Html<&'static str> {


### PR DESCRIPTION
## Summary

The dashboard was previously built into the source tree (`src/bridge/http/dashboard/dist`), which breaks `cargo publish` since crates.io builds happen in a read-only source directory. This moves the entire build process into `OUT_DIR` so pnpm and vite run entirely outside the source tree.

## Changes

- Added `copy_dir_recursive` helper in `build.rs` to copy dashboard sources (excluding `node_modules` and `dist`) into `OUT_DIR/dashboard` before building
- Changed `build_dashboard()` to use `OUT_DIR/dashboard` as the working directory for pnpm/vite, with output going to `OUT_DIR/dashboard/dist`
- Updated `include_str!` macros in `src/bridge/http/mod.rs` to reference assets from `OUT_DIR` via `env!("OUT_DIR")` and `concat!`
- Removed `cargo:rerun-if-changed` lines that tracked the old in-source `dist` directory

## Testing

The dashboard build now runs fully in `OUT_DIR`, which is writable in all contexts including `cargo publish` on crates.io.