### PR TITLE
query validate: make warnings non-fatal unless denied

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,10 @@ tracey query stale               # references pointing to older rule versions
 tracey query unmapped            # source tree with coverage percentages
 tracey query rule auth.login     # full details for a specific rule
 tracey query validate            # check for broken refs, naming issues
+tracey query validate --deny warnings # also fail on warnings
 ```
+
+`tracey query validate` exits non-zero on validation errors. Warnings are non-fatal by default, and become fatal only with `--deny warnings`.
 
 ### AI Skill (`tracey skill install`)
 

--- a/README.md.in
+++ b/README.md.in
@@ -188,7 +188,10 @@ tracey query stale               # references pointing to older rule versions
 tracey query unmapped            # source tree with coverage percentages
 tracey query rule auth.login     # full details for a specific rule
 tracey query validate            # check for broken refs, naming issues
+tracey query validate --deny warnings # also fail on warnings
 ```
+
+`tracey query validate` exits non-zero on validation errors. Warnings are non-fatal by default, and become fatal only with `--deny warnings`.
 
 ### AI Skill (`tracey skill install`)
 

--- a/crates/tracey/src/bridge/mcp.rs
+++ b/crates/tracey/src/bridge/mcp.rs
@@ -627,7 +627,7 @@ impl ServerHandler for TraceyHandler {
             "tracey_reload" => client.reload().await,
             "tracey_validate" => {
                 let spec_impl = args.get("spec_impl").and_then(|v| v.as_str());
-                client.validate(spec_impl).await.0
+                client.validate(spec_impl, false).await.0
             }
             "tracey_config_exclude" => {
                 let spec_impl = args.get("spec_impl").and_then(|v| v.as_str());

--- a/crates/tracey/src/bridge/query.rs
+++ b/crates/tracey/src/bridge/query.rs
@@ -508,14 +508,15 @@ impl QueryClient {
         self.with_config_banner(output).await
     }
 
-    pub async fn validate(&self, spec_impl: Option<&str>) -> (String, bool) {
+    pub async fn validate(&self, spec_impl: Option<&str>, deny_warnings: bool) -> (String, bool) {
         let (output, has_errors) = if spec_impl.is_some() {
             // If a specific spec/impl was requested, validate just that one.
             let (spec, impl_name) = parse_spec_impl(spec_impl);
             let req = ValidateRequest { spec, impl_name };
             match self.client.validate(req).await {
                 Ok(result) => {
-                    let has_errors = result.error_count > 0;
+                    let has_errors =
+                        result.error_count > 0 || (deny_warnings && result.warning_count > 0);
                     (format_validation_result(&result), has_errors)
                 }
                 Err(e) => (format!("Error: {e:?}"), true),
@@ -537,6 +538,7 @@ impl QueryClient {
                 let mut total_errors = 0;
                 let mut unique_unknown_rules: BTreeSet<String> = BTreeSet::new();
                 let mut unknown_reference_counts: BTreeMap<String, usize> = BTreeMap::new();
+                let mut total_warnings = 0usize;
                 let mut has_errors = false;
 
                 for impl_status in &status.impls {
@@ -548,7 +550,8 @@ impl QueryClient {
                     match self.client.validate(req).await {
                         Ok(result) => {
                             total_errors += result.error_count;
-                            has_errors |= result.error_count > 0;
+                            total_warnings += result.warning_count;
+                            has_errors = total_errors > 0 || (deny_warnings && total_warnings > 0);
                             let mut unknown_for_impl = 0usize;
                             let mut non_unknown_errors = Vec::new();
                             for error in &result.errors {
@@ -622,6 +625,9 @@ impl QueryClient {
                     status.impls.len(),
                     total_errors
                 ));
+                if total_warnings > 0 {
+                    output.push_str(&format!("Total warnings: {}\n", total_warnings));
+                }
                 if !unknown_reference_counts.is_empty() {
                     output.push_str(&format!(
                         "Unique unknown rules: {} ({} total occurrences)\n",

--- a/crates/tracey/src/main.rs
+++ b/crates/tracey/src/main.rs
@@ -264,7 +264,43 @@ enum QueryCommand {
         /// Spec/impl to validate (e.g., "my-spec/rust"). Optional if only one exists.
         #[facet(args::named, default)]
         spec_impl: Option<String>,
+
+        /// Diagnostics to deny as fatal (repeatable). Supported values: warnings.
+        #[facet(args::named, default)]
+        deny: Vec<String>,
     },
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct ValidationDeny {
+    warnings: bool,
+}
+
+impl ValidationDeny {
+    fn parse(values: &[String]) -> Result<Self> {
+        let mut deny = Self::default();
+        for raw in values {
+            for token in raw.split(',') {
+                let token = token.trim().to_ascii_lowercase();
+                if token.is_empty() {
+                    continue;
+                }
+                match token.as_str() {
+                    "warnings" | "warning" => deny.warnings = true,
+                    other => {
+                        return Err(eyre!(
+                            "unknown value for --deny: {other} (supported: warnings)"
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(deny)
+    }
+
+    fn should_fail(self, error_count: usize, warning_count: usize) -> bool {
+        error_count > 0 || (self.warnings && warning_count > 0)
+    }
 }
 
 // Embed the config schema for zero-execution discovery by styx tooling
@@ -467,8 +503,11 @@ async fn main() -> Result<()> {
                 ),
                 QueryCommand::Rule { rule_ids } => (query_client.rules(&rule_ids).await, false),
                 QueryCommand::Config => (query_client.config().await, false),
-                QueryCommand::Validate { spec_impl } => {
-                    query_client.validate(spec_impl.as_deref()).await
+                QueryCommand::Validate { spec_impl, deny } => {
+                    let deny = ValidationDeny::parse(&deny)?;
+                    query_client
+                        .validate(spec_impl.as_deref(), deny.warnings)
+                        .await
                 }
             };
 
@@ -604,13 +643,17 @@ async fn query_json(qc: &bridge::query::QueryClient, query: QueryCommand) -> (St
             ),
             Err(e) => (json_error(&format!("{e:?}")), false),
         },
-        QueryCommand::Validate { spec_impl } => {
+        QueryCommand::Validate { spec_impl, deny } => {
+            let deny = match ValidationDeny::parse(&deny) {
+                Ok(deny) => deny,
+                Err(e) => return (json_error(&e.to_string()), true),
+            };
             if spec_impl.is_some() {
                 let (spec, impl_name) = parse_spec_impl(spec_impl.as_deref());
                 let req = ValidateRequest { spec, impl_name };
                 match qc.client.validate(req).await {
                     Ok(resp) => {
-                        let has_errors = resp.error_count > 0;
+                        let has_errors = deny.should_fail(resp.error_count, resp.warning_count);
                         (
                             facet_json::to_string_pretty(&resp).expect("JSON serialization failed"),
                             has_errors,
@@ -626,7 +669,8 @@ async fn query_json(qc: &bridge::query::QueryClient, query: QueryCommand) -> (St
                 };
 
                 let mut results = Vec::new();
-                let mut has_errors = false;
+                let mut total_errors = 0usize;
+                let mut total_warnings = 0usize;
                 for impl_status in &status.impls {
                     let req = ValidateRequest {
                         spec: Some(impl_status.spec.clone()),
@@ -634,7 +678,8 @@ async fn query_json(qc: &bridge::query::QueryClient, query: QueryCommand) -> (St
                     };
                     match qc.client.validate(req).await {
                         Ok(result) => {
-                            has_errors |= result.error_count > 0;
+                            total_errors += result.error_count;
+                            total_warnings += result.warning_count;
                             results.push(result)
                         }
                         Err(e) => {
@@ -651,9 +696,44 @@ async fn query_json(qc: &bridge::query::QueryClient, query: QueryCommand) -> (St
 
                 let json =
                     facet_json::to_string_pretty(&results).expect("JSON serialization failed");
-                (json, has_errors)
+                (json, deny.should_fail(total_errors, total_warnings))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ValidationDeny;
+
+    #[test]
+    fn parse_validation_deny_accepts_warnings_variants() {
+        let deny = ValidationDeny::parse(&["warnings".to_string()]).expect("parse warnings");
+        assert!(deny.warnings);
+        let deny = ValidationDeny::parse(&["warning".to_string()]).expect("parse warning");
+        assert!(deny.warnings);
+        let deny =
+            ValidationDeny::parse(&["warnings,warning".to_string()]).expect("parse comma list");
+        assert!(deny.warnings);
+    }
+
+    #[test]
+    fn parse_validation_deny_rejects_unknown_values() {
+        let err = ValidationDeny::parse(&["errors".to_string()]).expect_err("should fail");
+        assert!(err.to_string().contains("unknown value for --deny"));
+    }
+
+    #[test]
+    fn validation_deny_default_only_fails_on_errors() {
+        let deny = ValidationDeny::default();
+        assert!(!deny.should_fail(0, 1));
+        assert!(deny.should_fail(1, 0));
+    }
+
+    #[test]
+    fn validation_deny_warnings_fails_on_warnings() {
+        let deny = ValidationDeny::parse(&["warnings".to_string()]).expect("parse warnings");
+        assert!(deny.should_fail(0, 1));
     }
 }
 

--- a/docs/content/guide/cli-reference.md
+++ b/docs/content/guide/cli-reference.md
@@ -185,8 +185,13 @@ tracey query config [ROOT]
 Run all validation checks: broken references, naming violations, circular dependencies, orphaned requirements, duplicates, stale references.
 
 ```
-tracey query validate [--spec_impl SPEC/IMPL] [ROOT]
+tracey query validate [--spec_impl SPEC/IMPL] [--deny warnings] [ROOT]
 ```
+
+Exit code behavior:
+- Fails (non-zero) when validation errors are present.
+- Warnings do not fail by default.
+- Use `--deny warnings` to make warnings fail the command.
 
 ## Spec versioning
 


### PR DESCRIPTION
## Summary
- make `tracey query validate` fail on errors by default, not warnings
- add `--deny warnings` / `--deny=warnings` to treat warnings as fatal
- apply the same exit-code policy to both text and `--json` output paths
- update query docs in README and CLI reference

## Notes
- follow-up to #161
- MCP `tracey_validate` behavior remains warnings-non-fatal by default

## Validation
- cargo check -p tracey
- cargo nextest run -p tracey validation_deny
