### PR TITLE
`pnpm` is required when you build from source

### DIFF
--- a/docs/content/guide/getting-started.md
+++ b/docs/content/guide/getting-started.md
@@ -16,6 +16,7 @@ curl --proto '=https' --tlsv1.2 -LsSf https://github.com/bearcove/tracey/release
 Or build from source:
 
 ```bash
+pnpm --version # pnpm is required
 cargo install --locked --git https://github.com/bearcove/tracey --branch main tracey
 ```
 


### PR DESCRIPTION
Hi, I wanted to give a try to tracey but I failed to build from source because I don't use `pnpm`. 

This PR updates the website instructions to let users know that pnpm needs to be installed before starting the build process.