### PR TITLE
Validate invalid spec_impl selections in query tools

### DIFF
--- a/crates/tracey/src/bridge/query.rs
+++ b/crates/tracey/src/bridge/query.rs
@@ -39,6 +39,61 @@ pub fn parse_spec_impl(spec_impl: Option<&str>) -> (Option<String>, Option<Strin
     }
 }
 
+fn valid_spec_impl_values(config: &ApiConfig) -> Vec<String> {
+    config
+        .specs
+        .iter()
+        .flat_map(|spec| {
+            spec.implementations
+                .iter()
+                .map(move |impl_name| format!("{}/{}", spec.name, impl_name))
+        })
+        .collect()
+}
+
+fn unknown_spec_impl_error(spec_impl: &str, config: &ApiConfig) -> String {
+    let valid_values = valid_spec_impl_values(config);
+    if valid_values.is_empty() {
+        format!("unknown spec_impl \"{spec_impl}\". No spec/impl combinations are configured")
+    } else {
+        format!(
+            "unknown spec_impl \"{spec_impl}\". Valid values: {}",
+            valid_values
+                .iter()
+                .map(|value| format!("\"{value}\""))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+}
+
+pub fn validate_spec_impl_selection(
+    spec_impl: Option<&str>,
+    config: &ApiConfig,
+) -> Result<(Option<String>, Option<String>), String> {
+    let Some(raw) = spec_impl else {
+        return Ok((None, None));
+    };
+
+    if raw.contains('/') {
+        let (spec, impl_name) = parse_spec_impl(Some(raw));
+        let spec_name = spec.as_deref().unwrap_or_default();
+        let impl_value = impl_name.as_deref().unwrap_or_default();
+        let is_valid = config.specs.iter().any(|entry| {
+            entry.name == spec_name && entry.implementations.iter().any(|v| v == impl_value)
+        });
+        if is_valid {
+            Ok((spec, impl_name))
+        } else {
+            Err(unknown_spec_impl_error(raw, config))
+        }
+    } else if config.specs.iter().any(|entry| entry.name == raw) {
+        Ok((Some(raw.to_string()), None))
+    } else {
+        Err(unknown_spec_impl_error(raw, config))
+    }
+}
+
 fn unknown_rule_reference_from_error(error: &ValidationError) -> Option<(String, String)> {
     let rule_id = error.reference_rule_id.as_ref()?.to_string();
     let reference = error
@@ -77,6 +132,18 @@ impl QueryClient {
         } else {
             output
         }
+    }
+
+    async fn checked_spec_impl(
+        &self,
+        spec_impl: Option<&str>,
+    ) -> Result<(Option<String>, Option<String>), String> {
+        let config = self
+            .client
+            .config()
+            .await
+            .map_err(|e| format!("failed to load config: {e:?}"))?;
+        validate_spec_impl_selection(spec_impl, &config)
     }
 
     fn hint(&self, cli_text: &str, mcp_text: &str) -> String {
@@ -201,7 +268,10 @@ impl QueryClient {
 
     /// Get rules without implementation references
     pub async fn uncovered(&self, spec_impl: Option<&str>, prefix: Option<&str>) -> String {
-        let (spec, impl_name) = parse_spec_impl(spec_impl);
+        let (spec, impl_name) = match self.checked_spec_impl(spec_impl).await {
+            Ok(values) => values,
+            Err(error) => return self.with_config_banner(format!("Error: {error}")).await,
+        };
 
         let req = UncoveredRequest {
             spec,
@@ -249,7 +319,10 @@ impl QueryClient {
 
     /// Get rules without verification references
     pub async fn untested(&self, spec_impl: Option<&str>, prefix: Option<&str>) -> String {
-        let (spec, impl_name) = parse_spec_impl(spec_impl);
+        let (spec, impl_name) = match self.checked_spec_impl(spec_impl).await {
+            Ok(values) => values,
+            Err(error) => return self.with_config_banner(format!("Error: {error}")).await,
+        };
 
         let req = UntestedRequest {
             spec,
@@ -297,7 +370,10 @@ impl QueryClient {
 
     /// Get code units without rule references
     pub async fn unmapped(&self, spec_impl: Option<&str>, path: Option<&str>) -> String {
-        let (spec, impl_name) = parse_spec_impl(spec_impl);
+        let (spec, impl_name) = match self.checked_spec_impl(spec_impl).await {
+            Ok(values) => values,
+            Err(error) => return self.with_config_banner(format!("Error: {error}")).await,
+        };
 
         let req = UnmappedRequest {
             spec,
@@ -375,7 +451,10 @@ impl QueryClient {
 
     /// Get stale references (code pointing to older rule versions)
     pub async fn stale(&self, spec_impl: Option<&str>, prefix: Option<&str>) -> String {
-        let (spec, impl_name) = parse_spec_impl(spec_impl);
+        let (spec, impl_name) = match self.checked_spec_impl(spec_impl).await {
+            Ok(values) => values,
+            Err(error) => return self.with_config_banner(format!("Error: {error}")).await,
+        };
 
         let req = StaleRequest {
             spec,
@@ -511,7 +590,15 @@ impl QueryClient {
     pub async fn validate(&self, spec_impl: Option<&str>, deny_warnings: bool) -> (String, bool) {
         let (output, has_errors) = if spec_impl.is_some() {
             // If a specific spec/impl was requested, validate just that one.
-            let (spec, impl_name) = parse_spec_impl(spec_impl);
+            let (spec, impl_name) = match self.checked_spec_impl(spec_impl).await {
+                Ok(values) => values,
+                Err(error) => {
+                    return (
+                        self.with_config_banner(format!("Error: {error}")).await,
+                        true,
+                    );
+                }
+            };
             let req = ValidateRequest { spec, impl_name };
             match self.client.validate(req).await {
                 Ok(result) => {
@@ -653,7 +740,10 @@ impl QueryClient {
     }
 
     pub async fn config_exclude(&self, spec_impl: Option<&str>, pattern: &str) -> String {
-        let (spec, impl_name) = parse_spec_impl(spec_impl);
+        let (spec, impl_name) = match self.checked_spec_impl(spec_impl).await {
+            Ok(values) => values,
+            Err(error) => return self.with_config_banner(format!("Error: {error}")).await,
+        };
 
         let req = ConfigPatternRequest {
             spec,
@@ -670,7 +760,10 @@ impl QueryClient {
     }
 
     pub async fn config_include(&self, spec_impl: Option<&str>, pattern: &str) -> String {
-        let (spec, impl_name) = parse_spec_impl(spec_impl);
+        let (spec, impl_name) = match self.checked_spec_impl(spec_impl).await {
+            Ok(values) => values,
+            Err(error) => return self.with_config_banner(format!("Error: {error}")).await,
+        };
 
         let req = ConfigPatternRequest {
             spec,
@@ -787,11 +880,56 @@ fn format_validation_result(result: &tracey_proto::ValidationResult) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{format_rule_info, format_validation_result};
+    use super::{format_rule_info, format_validation_result, validate_spec_impl_selection};
+    use tracey_api::{ApiConfig, ApiSpecInfo};
     use tracey_core::parse_rule_id;
     use tracey_proto::{
         ApiCodeRef, RuleCoverage, RuleInfo, ValidationError, ValidationErrorCode, ValidationResult,
     };
+
+    fn sample_config() -> ApiConfig {
+        ApiConfig {
+            project_root: "/tmp/project".to_string(),
+            specs: vec![
+                ApiSpecInfo {
+                    name: "ship".to_string(),
+                    prefix: "r".to_string(),
+                    source: None,
+                    source_url: None,
+                    implementations: vec!["rust".to_string(), "typescript".to_string()],
+                },
+                ApiSpecInfo {
+                    name: "other".to_string(),
+                    prefix: "r".to_string(),
+                    source: None,
+                    source_url: None,
+                    implementations: vec!["rust".to_string()],
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn validate_spec_impl_selection_accepts_known_full_value() {
+        let config = sample_config();
+        let actual = validate_spec_impl_selection(Some("ship/typescript"), &config)
+            .expect("expected valid spec/impl");
+        assert_eq!(
+            actual,
+            (Some("ship".to_string()), Some("typescript".to_string()))
+        );
+    }
+
+    #[test]
+    fn validate_spec_impl_selection_rejects_unknown_value_with_valid_choices() {
+        let config = sample_config();
+        let error = validate_spec_impl_selection(Some("typescript"), &config)
+            .expect_err("expected invalid bare impl name to fail");
+        assert_eq!(
+            error,
+            "unknown spec_impl \"typescript\". Valid values: \"ship/rust\", \"ship/typescript\", \"other/rust\""
+        );
+    }
 
     #[test]
     fn stale_validation_output_is_concise() {

--- a/crates/tracey/src/main.rs
+++ b/crates/tracey/src/main.rs
@@ -540,7 +540,7 @@ fn json_error(message: &str) -> String {
 /// Handle `tracey query --json <subcommand>` by calling the daemon client
 /// directly and serializing the typed response as JSON.
 async fn query_json(qc: &bridge::query::QueryClient, query: QueryCommand) -> (String, bool) {
-    use bridge::query::parse_spec_impl;
+    use bridge::query::{parse_spec_impl, validate_spec_impl_selection};
     use tracey_proto::*;
 
     match query {
@@ -552,7 +552,21 @@ async fn query_json(qc: &bridge::query::QueryClient, query: QueryCommand) -> (St
             Err(e) => (json_error(&format!("{e:?}")), false),
         },
         QueryCommand::Uncovered { spec_impl, prefix } => {
-            let (spec, impl_name) = parse_spec_impl(spec_impl.as_deref());
+            let (spec, impl_name) = match spec_impl.as_deref() {
+                Some(raw) => {
+                    let config = match qc.client.config().await {
+                        Ok(config) => config,
+                        Err(e) => {
+                            return (json_error(&format!("failed to load config: {e:?}")), false);
+                        }
+                    };
+                    match validate_spec_impl_selection(Some(raw), &config) {
+                        Ok(values) => values,
+                        Err(error) => return (json_error(&error), false),
+                    }
+                }
+                None => parse_spec_impl(None),
+            };
             let req = UncoveredRequest {
                 spec,
                 impl_name,
@@ -567,7 +581,21 @@ async fn query_json(qc: &bridge::query::QueryClient, query: QueryCommand) -> (St
             }
         }
         QueryCommand::Untested { spec_impl, prefix } => {
-            let (spec, impl_name) = parse_spec_impl(spec_impl.as_deref());
+            let (spec, impl_name) = match spec_impl.as_deref() {
+                Some(raw) => {
+                    let config = match qc.client.config().await {
+                        Ok(config) => config,
+                        Err(e) => {
+                            return (json_error(&format!("failed to load config: {e:?}")), false);
+                        }
+                    };
+                    match validate_spec_impl_selection(Some(raw), &config) {
+                        Ok(values) => values,
+                        Err(error) => return (json_error(&error), false),
+                    }
+                }
+                None => parse_spec_impl(None),
+            };
             let req = UntestedRequest {
                 spec,
                 impl_name,
@@ -582,7 +610,21 @@ async fn query_json(qc: &bridge::query::QueryClient, query: QueryCommand) -> (St
             }
         }
         QueryCommand::Stale { spec_impl, prefix } => {
-            let (spec, impl_name) = parse_spec_impl(spec_impl.as_deref());
+            let (spec, impl_name) = match spec_impl.as_deref() {
+                Some(raw) => {
+                    let config = match qc.client.config().await {
+                        Ok(config) => config,
+                        Err(e) => {
+                            return (json_error(&format!("failed to load config: {e:?}")), false);
+                        }
+                    };
+                    match validate_spec_impl_selection(Some(raw), &config) {
+                        Ok(values) => values,
+                        Err(error) => return (json_error(&error), false),
+                    }
+                }
+                None => parse_spec_impl(None),
+            };
             let req = StaleRequest {
                 spec,
                 impl_name,
@@ -597,7 +639,21 @@ async fn query_json(qc: &bridge::query::QueryClient, query: QueryCommand) -> (St
             }
         }
         QueryCommand::Unmapped { spec_impl, path } => {
-            let (spec, impl_name) = parse_spec_impl(spec_impl.as_deref());
+            let (spec, impl_name) = match spec_impl.as_deref() {
+                Some(raw) => {
+                    let config = match qc.client.config().await {
+                        Ok(config) => config,
+                        Err(e) => {
+                            return (json_error(&format!("failed to load config: {e:?}")), false);
+                        }
+                    };
+                    match validate_spec_impl_selection(Some(raw), &config) {
+                        Ok(values) => values,
+                        Err(error) => return (json_error(&error), false),
+                    }
+                }
+                None => parse_spec_impl(None),
+            };
             let req = UnmappedRequest {
                 spec,
                 impl_name,
@@ -649,7 +705,15 @@ async fn query_json(qc: &bridge::query::QueryClient, query: QueryCommand) -> (St
                 Err(e) => return (json_error(&e.to_string()), true),
             };
             if spec_impl.is_some() {
-                let (spec, impl_name) = parse_spec_impl(spec_impl.as_deref());
+                let config = match qc.client.config().await {
+                    Ok(config) => config,
+                    Err(e) => return (json_error(&format!("failed to load config: {e:?}")), true),
+                };
+                let (spec, impl_name) =
+                    match validate_spec_impl_selection(spec_impl.as_deref(), &config) {
+                        Ok(values) => values,
+                        Err(error) => return (json_error(&error), true),
+                    };
                 let req = ValidateRequest { spec, impl_name };
                 match qc.client.validate(req).await {
                     Ok(resp) => {


### PR DESCRIPTION
## Summary
Validate `spec_impl` selections before query tools fall back to defaults so invalid values return a real error instead of a misleading empty result.
This updates the shared query bridge and JSON query path to report the valid `spec/impl` combinations from config.

## Changes
- add shared `spec_impl` validation against the loaded Tracey config
- return explicit unknown-`spec_impl` errors with valid values for uncovered, untested, stale, unmapped, validate, and config include/exclude query paths
- apply the same validation to `tracey query --json` for the affected subcommands
- add focused unit tests for accepted and rejected `spec_impl` values

## Testing
- `cargo fmt`
- `cargo check`
- `cargo nextest run -p tracey -E 'test(validate_spec_impl_selection_)'`

Closes #164
