### PR TITLE
Fix incorrect hint for `tracey query validate` spec-impl flag (#151)

### DIFF
--- a/crates/tracey/src/bridge/query.rs
+++ b/crates/tracey/src/bridge/query.rs
@@ -729,8 +729,8 @@ impl QueryClient {
                     }
                 }
                 output.push_str(&self.hint(
-                    "tracey query validate <spec>/<impl>",
-                    "tracey_validate with a spec_impl parameter to validate a specific one (e.g., \"my-spec/rust\")",
+                    "tracey query validate --spec-impl <spec>/<impl>",
+                    "tracey_validate with a spec-impl parameter to validate a specific one (e.g., \"my-spec/rust\")",
                 ));
                 (output, has_errors)
             }


### PR DESCRIPTION
The hint suggested positional syntax `<spec>/<impl>` but the argument is actually a named flag `--spec-impl`. This PR won't be complete until a new version of `figue` is available with bearcove/figue#76 merged, at which point we can bump `figue` to the latest version and get the help message for the flag to render correctly.