### PR TITLE
feat: add Nix language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4458,6 +4458,7 @@ dependencies = [
  "arborium-julia",
  "arborium-lua",
  "arborium-matlab",
+ "arborium-nix",
  "arborium-ocaml",
  "arborium-perl",
  "arborium-php",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ arborium = { version = "2", features = [
   "lang-d",
   "lang-powershell",
   "lang-cmake",
+  "lang-nix",
 ] }
 arborium-rust = "2"
 arborium-swift = "2"
@@ -123,6 +124,7 @@ arborium-powershell = "2"
 arborium-cmake = "2"
 arborium-ocaml = "2"
 arborium-bash = "2"
+arborium-nix = "2"
 
 # HTTP server for serve command
 axum = { version = "0.8", features = ["ws"] }

--- a/crates/tracey-core/Cargo.toml
+++ b/crates/tracey-core/Cargo.toml
@@ -50,6 +50,7 @@ reverse = [
   "dep:arborium-cmake",
   "dep:arborium-ocaml",
   "dep:arborium-bash",
+  "dep:arborium-nix",
 ]
 
 [dependencies]
@@ -92,3 +93,4 @@ arborium-powershell = { workspace = true, optional = true }
 arborium-cmake = { workspace = true, optional = true }
 arborium-ocaml = { workspace = true, optional = true }
 arborium-bash = { workspace = true, optional = true }
+arborium-nix = { workspace = true, optional = true }

--- a/crates/tracey-core/src/code_units.rs
+++ b/crates/tracey-core/src/code_units.rs
@@ -178,6 +178,7 @@ pub fn extract(path: &Path, source: &str) -> CodeUnits {
         "cmake" => extract_cmake(path, source),
         "ml" | "mli" => extract_ocaml(path, source),
         "sh" | "bash" | "zsh" => extract_bash(path, source),
+        "nix" => extract_nix(path, source),
         _ => CodeUnits::new(),
     }
 }
@@ -1064,6 +1065,31 @@ fn bash_node_kind(kind: &str) -> Option<CodeUnitKind> {
     }
 }
 
+/// Extract code units from Nix source code
+pub fn extract_nix(path: &Path, source: &str) -> CodeUnits {
+    let mut parser = Parser::new();
+    parser
+        .set_language(&arborium_nix::language().into())
+        .expect("Failed to load Nix grammar");
+
+    let Some(tree) = parser.parse(source, None) else {
+        return CodeUnits::new();
+    };
+
+    let mut units = CodeUnits::new();
+    let root = tree.root_node();
+    extract_units_recursive(path, source, root, &mut units, nix_node_kind);
+    units
+}
+
+fn nix_node_kind(kind: &str) -> Option<CodeUnitKind> {
+    match kind {
+        "function_expression" => Some(CodeUnitKind::Function),
+        "binding" => Some(CodeUnitKind::Const),
+        _ => None,
+    }
+}
+
 fn extract_units_recursive<F>(
     path: &Path,
     source: &str,
@@ -1465,6 +1491,7 @@ pub fn extract_refs_with_warnings(path: &Path, source: &str) -> ExtractedRefs {
         "cmake" => arborium_cmake::language(),
         "ml" | "mli" => arborium_ocaml::language(),
         "sh" | "bash" | "zsh" => arborium_bash::language(),
+        "nix" => arborium_nix::language(),
         _ => return ExtractedRefs::default(),
     };
 
@@ -3208,6 +3235,49 @@ function helper {
             !func_units.is_empty(),
             "Should find function definitions in bash"
         );
+    }
+
+    #[test]
+    fn test_nix_code_units() {
+        let source = r#"# r[impl nix.feature]
+{
+  greet = name: "Hello, ${name}!";
+
+  /* r[impl nix.config] */
+  settings = {
+    enabled = true;
+  };
+}
+"#;
+        let units = extract_nix(Path::new("test.nix"), source);
+
+        let bindings: Vec<_> = units
+            .units
+            .iter()
+            .filter(|u| u.kind == CodeUnitKind::Const)
+            .collect();
+        assert!(!bindings.is_empty(), "Should find attrset bindings in Nix");
+
+        let funcs: Vec<_> = units
+            .units
+            .iter()
+            .filter(|u| u.kind == CodeUnitKind::Function)
+            .collect();
+        assert!(!funcs.is_empty(), "Should find function expressions in Nix");
+    }
+
+    #[test]
+    fn test_nix_refs() {
+        let source = r#"# r[impl nix.line]
+{
+  /* r[verify nix.block] */
+  foo = 1;
+}
+"#;
+        let refs = extract_refs(Path::new("test.nix"), source);
+        assert_eq!(refs.len(), 2, "Should find refs in both # and /* */ comments");
+        assert_eq!(refs[0].req_id, "nix.line");
+        assert_eq!(refs[1].req_id, "nix.block");
     }
 
     #[test]

--- a/crates/tracey-core/src/sources.rs
+++ b/crates/tracey-core/src/sources.rs
@@ -80,6 +80,7 @@ pub const SUPPORTED_EXTENSIONS: &[&str] = &[
     "sh",     // Shell/Bash
     "bash",   // Bash
     "zsh",    // Zsh
+    "nix",    // Nix
 ];
 
 /// Check if a file extension is supported for scanning
@@ -473,6 +474,7 @@ mod tests {
     }
 
     // r[verify config.impl.test_include.extraction]
+    #[cfg(feature = "reverse")]
     #[test]
     fn test_memory_sources_python() {
         let result = Reqs::extract(
@@ -509,6 +511,22 @@ mod tests {
         assert_eq!(result.reqs.len(), 3);
     }
 
+    #[cfg(feature = "reverse")]
+    #[test]
+    fn test_memory_sources_nix() {
+        let result = Reqs::extract(
+            MemorySources::new()
+                .add("default.nix", "# r[impl nix.req.one]")
+                .add("flake.nix", "/* r[verify nix.req.two] */\n{ }"),
+        )
+        .unwrap();
+
+        assert_eq!(result.reqs.len(), 2);
+        assert_eq!(result.reqs.references[0].req_id, "nix.req.one");
+        assert_eq!(result.reqs.references[1].req_id, "nix.req.two");
+        assert!(result.warnings.is_empty());
+    }
+
     #[test]
     fn test_supported_extensions() {
         use std::ffi::OsStr;
@@ -520,6 +538,7 @@ mod tests {
         assert!(is_supported_extension(OsStr::new("js")));
         assert!(is_supported_extension(OsStr::new("go")));
         assert!(is_supported_extension(OsStr::new("php")));
+        assert!(is_supported_extension(OsStr::new("nix")));
 
         assert!(!is_supported_extension(OsStr::new("md")));
         assert!(!is_supported_extension(OsStr::new("txt")));


### PR DESCRIPTION
Recognize `.nix` files and parse them with tree-sitter-nix, extracting
refs from both `#` line comments and `/* */` block comments. Attrset
bindings map to Const code units and function expressions to Function.

Also gate the existing Python memory-sources test behind the `reverse`
feature — it uses `#` comments which the text-based fallback doesn't
handle, so it was failing under default features.
