### PR TITLE
Migrate from roam to vox RPC framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,6 +1457,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-cbor"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51d4c1c7511cf82fadc0eb85e9c97e03751acf8b8cd8ef4954bb5a56d0198a8"
+dependencies = [
+ "facet",
+ "facet-core",
+ "facet-reflect",
+]
+
+[[package]]
 name = "facet-core"
 version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,21 +1596,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ae380f4553db1a2ab33fb75035e7d86c178f384c4ded2e1681daec58cbbfc2"
 dependencies = [
  "facet-core",
-]
-
-[[package]]
-name = "facet-postcard"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec32d82e6375dc12fed002e89cc18846fe63a501cb5e4f235e84e262a4fa9d32"
-dependencies = [
- "camino",
- "facet-core",
- "facet-format",
- "facet-path",
- "facet-reflect",
- "facet-value",
- "tracing",
 ]
 
 [[package]]
@@ -3312,125 +3308,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
-name = "roam"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c65e85a0f43bd085f7230ec3de1f396fa76f3bab06ed73665b411ea9571352d"
-dependencies = [
- "facet",
- "facet-postcard",
- "roam-core",
- "roam-hash",
- "roam-service-macros",
- "roam-types",
-]
-
-[[package]]
-name = "roam-core"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca4712ba9acfbb6a8d582862a8db99f30edcf23cd776d8b3749a9e413ca91f5"
-dependencies = [
- "facet",
- "facet-core",
- "facet-error",
- "facet-format",
- "facet-postcard",
- "facet-reflect",
- "getrandom 0.3.4",
- "moire",
- "roam-types",
- "smallvec 1.15.1",
- "tokio",
- "tracing",
- "wasm-bindgen-futures",
- "zerocopy",
-]
-
-[[package]]
-name = "roam-hash"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c90ee51fc268cb1007c66ab3bed504773f796cf601e1813fa78d36ea9dbac74"
-dependencies = [
- "blake3",
- "facet-core",
- "heck",
- "roam-types",
-]
-
-[[package]]
-name = "roam-local"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "880e84d526ce7358cd1f6073d4147c3832ee45f3943262c978f8c4222c3c7e60"
-dependencies = [
- "moire",
- "tokio",
-]
-
-[[package]]
-name = "roam-macros-core"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6120ec157aa9af0e26c4d964f72f477f5ca1e8305a9f9460a39ff91d311ad4a8"
-dependencies = [
- "facet-cargo-toml",
- "heck",
- "proc-macro2",
- "quote",
- "roam-macros-parse",
-]
-
-[[package]]
-name = "roam-macros-parse"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad22d81611eb65e7e89ab7b3c7379af806d3eca8a814ecf1b7a3d985f8486a9c"
-dependencies = [
- "proc-macro2",
- "unsynn",
-]
-
-[[package]]
-name = "roam-service-macros"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e289e88b1f67a00097d637c95c57d7ccecea8da364d882c125144977f43e9d8a"
-dependencies = [
- "proc-macro2",
- "roam-macros-core",
-]
-
-[[package]]
-name = "roam-stream"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483987f99c071e9039acb07632993a9c7740516f36153bae87f9d287e0ebb959"
-dependencies = [
- "moire",
- "roam-types",
- "tokio",
-]
-
-[[package]]
-name = "roam-types"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37333cc6a1bd76ada6b8a9ef7d6bed6d155be7baca3dcd0bd052ce881a724cc2"
-dependencies = [
- "bitflags 2.11.0",
- "facet",
- "facet-core",
- "facet-path",
- "facet-postcard",
- "futures-channel",
- "smallvec 1.15.1",
- "structstruck",
- "tokio",
-]
-
-[[package]]
 name = "rowan"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4395,10 +4272,6 @@ dependencies = [
  "notify",
  "open",
  "owo-colors",
- "roam",
- "roam-core",
- "roam-local",
- "roam-stream",
  "rust-mcp-sdk",
  "serde",
  "serde_json",
@@ -4419,6 +4292,10 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "urlencoding",
+ "vox",
+ "vox-core",
+ "vox-local",
+ "vox-stream",
 ]
 
 [[package]]
@@ -4485,9 +4362,9 @@ name = "tracey-proto"
 version = "1.3.0"
 dependencies = [
  "facet",
- "roam",
  "tracey-api",
  "tracey-core",
+ "vox",
 ]
 
 [[package]]
@@ -4714,6 +4591,145 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vox"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1ea898f15bbd3d1f5e3795470928beb7a80dcdcf7a100d1316d28b56a8bb4b"
+dependencies = [
+ "facet",
+ "tracing",
+ "vox-core",
+ "vox-postcard",
+ "vox-service-macros",
+ "vox-types",
+]
+
+[[package]]
+name = "vox-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee1b808eb97ec31e36567caa303f20fac9e745dd6ef19b6b8767478677639b30"
+dependencies = [
+ "facet",
+ "facet-cbor",
+ "facet-core",
+ "facet-error",
+ "facet-reflect",
+ "getrandom 0.3.4",
+ "moire",
+ "smallvec 1.15.1",
+ "tokio",
+ "tracing",
+ "vox-postcard",
+ "vox-types",
+ "wasm-bindgen-futures",
+ "zerocopy",
+]
+
+[[package]]
+name = "vox-local"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "208a9015db7a855fc202aa5ec31537bb64dd3768eab714300e8c28ada3c4ba09"
+dependencies = [
+ "moire",
+ "tokio",
+]
+
+[[package]]
+name = "vox-macros-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9835e61aa64cc2317424af75cda2da516c0ab985cb3ed97be287c2738cf1dad8"
+dependencies = [
+ "facet-cargo-toml",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "vox-macros-parse",
+]
+
+[[package]]
+name = "vox-macros-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58da604c34878eec374213d62151862f9794c8595b0615f823ea9c5133f2efc9"
+dependencies = [
+ "proc-macro2",
+ "unsynn",
+]
+
+[[package]]
+name = "vox-postcard"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a2fe5aadbf23e581e0cbf53417dc769992da887e38b36fc2daf9580059b34e"
+dependencies = [
+ "facet",
+ "facet-core",
+ "facet-reflect",
+ "vox-schema",
+]
+
+[[package]]
+name = "vox-schema"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99feee2df54ce8e6378942c2597939afca54b16fbde2e27fafc7563bf3cb6d72"
+dependencies = [
+ "blake3",
+ "facet",
+ "facet-cbor",
+ "facet-core",
+ "indexmap",
+]
+
+[[package]]
+name = "vox-service-macros"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b10dc949f985bf6c094a9f4ff49cf038d2b6236a83010831253d1c10602d6f"
+dependencies = [
+ "proc-macro2",
+ "vox-macros-core",
+]
+
+[[package]]
+name = "vox-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f61908719b4faea59529224d5d5f8a1b46d75c8299c78848eb27fc62112bf054"
+dependencies = [
+ "moire",
+ "tokio",
+ "vox-core",
+ "vox-types",
+]
+
+[[package]]
+name = "vox-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93496d65949636e697ad9a2d8e941721a9ed00770750e8cef76c950e72ecd888"
+dependencies = [
+ "bitflags 2.11.0",
+ "blake3",
+ "facet",
+ "facet-cbor",
+ "facet-core",
+ "facet-path",
+ "futures-channel",
+ "heck",
+ "indexmap",
+ "moire",
+ "smallvec 1.15.1",
+ "structstruck",
+ "tokio",
+ "vox-postcard",
+ "vox-schema",
+]
 
 [[package]]
 name = "vte"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,7 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "facet-cbor"
-version = "0.2.0"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44a78e302a804170ac74780d8350a0d8036226ee8448ca653897fde12228a577"
 dependencies = [
  "facet",
  "facet-core",
@@ -2686,7 +2688,8 @@ dependencies = [
 [[package]]
 name = "moire"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac52dcc0ff5b4710a66626370b1bf85ba3d924fd8019e8cfa100e8dafffda4ad"
 dependencies = [
  "moire-macros-noop",
  "moire-tokio",
@@ -2696,12 +2699,14 @@ dependencies = [
 [[package]]
 name = "moire-macros-noop"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ccdc0bf403f5ecf29c09e8e9f178caed89a914ea032e0c2d99d3824b78892d"
 
 [[package]]
 name = "moire-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568cc05b223c4c76247467e3bdaa7862f05c38d5c8f6e44198613880f90ecd98"
 dependencies = [
  "ctor",
  "facet",
@@ -2717,8 +2722,10 @@ dependencies = [
 [[package]]
 name = "moire-tokio"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb30c43038ce71c727da5a4ff01d09dd4c823486cc17b3b08661420d0ceda43"
 dependencies = [
+ "ctor",
  "moire-runtime",
  "moire-types",
  "parking_lot",
@@ -2728,7 +2735,8 @@ dependencies = [
 [[package]]
 name = "moire-trace-capture"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6685ebbdee1253529c9074c41d8288504b640ffe8c21176ce464fef5c5c00c38"
 dependencies = [
  "libc",
  "moire-trace-types",
@@ -2737,7 +2745,8 @@ dependencies = [
 [[package]]
 name = "moire-trace-types"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ef6f98b447211257a517d101f0f5cf4300627cd6fd1c0c13ff53d157a872c9d"
 dependencies = [
  "facet",
 ]
@@ -2745,7 +2754,8 @@ dependencies = [
 [[package]]
 name = "moire-types"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667b2fc41e30d3b0f7d0d29e978d3f473afaf0e0be355202eead317e35ace200"
 dependencies = [
  "facet",
  "facet-value",
@@ -2755,7 +2765,8 @@ dependencies = [
 [[package]]
 name = "moire-wasm"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f143cef34407271acdbca3af106d82b330693e0990ef87df146441392d8a9577"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2770,7 +2781,8 @@ dependencies = [
 [[package]]
 name = "moire-wire"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0ec84eeb2e23a83339cf5edc9d5a3a9ec5849416bd4051951fba416ea3e0f7"
 dependencies = [
  "facet",
  "facet-json",
@@ -4582,7 +4594,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vox"
-version = "0.2.0"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae75f6e8068fd96e32cefc4897c2b3f0369a43b7640fcfef8c0ef0810070899"
 dependencies = [
  "facet",
  "tracing",
@@ -4594,7 +4608,9 @@ dependencies = [
 
 [[package]]
 name = "vox-core"
-version = "0.2.0"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80b37b56aef6db57b629fd7029bf68fe9c92ed08e92191d5ee510f66b56f849d"
 dependencies = [
  "facet",
  "facet-cbor",
@@ -4614,7 +4630,9 @@ dependencies = [
 
 [[package]]
 name = "vox-local"
-version = "0.2.0"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4053e7496487b934b8c99e2d334487e8e86fe9fe3ef8c3da87b440b03f09a56"
 dependencies = [
  "moire",
  "tokio",
@@ -4622,7 +4640,9 @@ dependencies = [
 
 [[package]]
 name = "vox-macros-core"
-version = "0.2.0"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2230b25a7123be3f9932a919f47005050723e7eade8d12f732066078a960fd"
 dependencies = [
  "facet-cargo-toml",
  "heck",
@@ -4633,7 +4653,9 @@ dependencies = [
 
 [[package]]
 name = "vox-macros-parse"
-version = "0.2.0"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e414d81430b9fa6c232b313f68bf4b51fb1432559088f103f65180c5137283aa"
 dependencies = [
  "proc-macro2",
  "unsynn",
@@ -4641,7 +4663,9 @@ dependencies = [
 
 [[package]]
 name = "vox-postcard"
-version = "0.2.0"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12570182015956ec7f56e6095a8b9697c3fcea37c9235c508ed2bb8133cd05a"
 dependencies = [
  "facet",
  "facet-core",
@@ -4651,7 +4675,9 @@ dependencies = [
 
 [[package]]
 name = "vox-schema"
-version = "0.2.0"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4d51b82b95aee0c32e37887c9551fe822d9ef491ca77d7283f28a750004e96d"
 dependencies = [
  "blake3",
  "facet",
@@ -4662,7 +4688,9 @@ dependencies = [
 
 [[package]]
 name = "vox-service-macros"
-version = "0.2.0"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98796a94d18cc3a7f37415798db214f1068c0faf9f2e093e94334a8f81fb0377"
 dependencies = [
  "proc-macro2",
  "vox-macros-core",
@@ -4670,7 +4698,9 @@ dependencies = [
 
 [[package]]
 name = "vox-stream"
-version = "0.2.0"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bfe52bf2e811869a9fc762e06a253c92749dc41efc621cea65d45a2255e9223"
 dependencies = [
  "moire",
  "tokio",
@@ -4680,7 +4710,9 @@ dependencies = [
 
 [[package]]
 name = "vox-types"
-version = "0.2.0"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22861e99512412f489f9e1f9041d8d28b320aef8dcf4eb8f3a694d3617bd1e95"
 dependencies = [
  "bitflags 2.11.0",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,9 +1421,9 @@ dependencies = [
 
 [[package]]
 name = "facet"
-version = "0.44.1"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c578b0cf6efa3459c6ff5f9f67ddfa668ba778fdbf301a1ba6bb493bf32aba"
+checksum = "4aa60b7d3d49d30f477f9490b7fc3ce42009b5b626b625b0356742884c493a11"
 dependencies = [
  "autocfg",
  "facet-core",
@@ -1458,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "facet-cbor"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44a78e302a804170ac74780d8350a0d8036226ee8448ca653897fde12228a577"
+checksum = "b89019be41ea06075e724e3bb18064c201a28c08bddb3616bb26cf9993833bf3"
 dependencies = [
  "facet",
  "facet-core",
@@ -1469,9 +1469,9 @@ dependencies = [
 
 [[package]]
 name = "facet-core"
-version = "0.44.1"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2c09e5a796b8989e7555cbe097ddd3c3ffa4c02392b9b4ad0d7cd48b1af5c2"
+checksum = "11f9ee47507f15c18243a8cba3b2a85b71176173f0097e9164a54dd4e4e3e4ce"
 dependencies = [
  "autocfg",
  "camino",
@@ -1507,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "facet-error"
-version = "0.44.1"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19f1faf0c1074b7584a43774789e06234f839dc7207ff3fcf2fbd7902429f96"
+checksum = "1f4ad09f4efc4d87eaa1122dbd194caac256ce0c4002b799ffe3f346cdc1ad01"
 dependencies = [
  "facet",
 ]
@@ -1546,9 +1546,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macro-parse"
-version = "0.44.1"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ecddfa2b01f0ea083571f9cbb945222bc6603ce2c1cad9105eb8a432e09298"
+checksum = "e77becc35b3b3008e7b3ef23356954e46561177316aff0a92c73fc6ddb2a15a0"
 dependencies = [
  "facet-macro-types",
  "proc-macro2",
@@ -1557,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macro-types"
-version = "0.44.1"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22ff06d4c4bb3cc6cfaf51d20c66444d7845ab047a7cd500b2677f01a9f6fd9"
+checksum = "8e600db5983cdad99db3b34adfa20b546d80f21ab8feecd35d40bbbfbcf53b5c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1568,18 +1568,18 @@ dependencies = [
 
 [[package]]
 name = "facet-macros"
-version = "0.44.1"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd4fe21b304e67937988fd88ef0907453a11921597fddff8ea8dc711575bfc7"
+checksum = "a3a7015e119aa043740dc8aee6b1b70e26b6616e1701b329496bf04990f44133"
 dependencies = [
  "facet-macros-impl",
 ]
 
 [[package]]
 name = "facet-macros-impl"
-version = "0.44.1"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b050ae34e587b27fa45e33720722be8ccc20a3d64f4560882cffae1ce65c564f"
+checksum = "cbb5e6f6cc64210ab12aa625b014db78d34d6a3b63d1011382c141518a1e1f78"
 dependencies = [
  "facet-macro-parse",
  "facet-macro-types",
@@ -1591,18 +1591,18 @@ dependencies = [
 
 [[package]]
 name = "facet-path"
-version = "0.44.1"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ae380f4553db1a2ab33fb75035e7d86c178f384c4ded2e1681daec58cbbfc2"
+checksum = "77e7b83cb0de7c00d6e76f08d36b047d6cb9efc39e10744dbcf7a4a5a19c4903"
 dependencies = [
  "facet-core",
 ]
 
 [[package]]
 name = "facet-pretty"
-version = "0.44.1"
+version = "0.44.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "682119408855d2a5de7cc23b0477ed19e332e0272caa110063eeda82d8809cc2"
+checksum = "0b93416595a402722978717593f38b3d51ab17b5cc1d914305b1758f02651ead"
 dependencies = [
  "facet-core",
  "facet-reflect",
@@ -1611,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "facet-reflect"
-version = "0.44.1"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2469bdb237a3f3cac3077b784e86be88e379534ff9322d53b3d673e27bcb0988"
+checksum = "e9cc255bd928399489868fdddec09e69073d622432cc2b52cfa3c3a5d811305c"
 dependencies = [
  "facet-core",
  "facet-path",
@@ -4594,11 +4594,13 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vox"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae75f6e8068fd96e32cefc4897c2b3f0369a43b7640fcfef8c0ef0810070899"
+checksum = "5ae2094aa7173b3c28427ec1d20cebd98f45c22a46e09294b7ce0413bca3cb4b"
 dependencies = [
  "facet",
+ "facet-pretty",
+ "facet-reflect",
  "tracing",
  "vox-core",
  "vox-postcard",
@@ -4608,9 +4610,9 @@ dependencies = [
 
 [[package]]
 name = "vox-core"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b37b56aef6db57b629fd7029bf68fe9c92ed08e92191d5ee510f66b56f849d"
+checksum = "48d3404fab6d551e3890369501ebfaa170ca8b4d973b86eec3ae924e0bb9e8c2"
 dependencies = [
  "facet",
  "facet-cbor",
@@ -4630,9 +4632,9 @@ dependencies = [
 
 [[package]]
 name = "vox-local"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4053e7496487b934b8c99e2d334487e8e86fe9fe3ef8c3da87b440b03f09a56"
+checksum = "52c42e07429c5494b51563192a8a36c2e8396569faaeccdfc77c0fe0600eb881"
 dependencies = [
  "moire",
  "tokio",
@@ -4640,9 +4642,9 @@ dependencies = [
 
 [[package]]
 name = "vox-macros-core"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2230b25a7123be3f9932a919f47005050723e7eade8d12f732066078a960fd"
+checksum = "9047b79fae422b8e1a5d15fe55108bc2a1484aff94662932aa14bcc6ecde1b7e"
 dependencies = [
  "facet-cargo-toml",
  "heck",
@@ -4653,9 +4655,9 @@ dependencies = [
 
 [[package]]
 name = "vox-macros-parse"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e414d81430b9fa6c232b313f68bf4b51fb1432559088f103f65180c5137283aa"
+checksum = "8f687c5813a5826e900753ec736896bf57997ceb15180bdffc9841f43345901a"
 dependencies = [
  "proc-macro2",
  "unsynn",
@@ -4663,9 +4665,9 @@ dependencies = [
 
 [[package]]
 name = "vox-postcard"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12570182015956ec7f56e6095a8b9697c3fcea37c9235c508ed2bb8133cd05a"
+checksum = "813a4858832dd8eee753b2a1a3a90d5a03e7a51871e019f23d3979c7a98814f5"
 dependencies = [
  "facet",
  "facet-core",
@@ -4675,9 +4677,9 @@ dependencies = [
 
 [[package]]
 name = "vox-schema"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d51b82b95aee0c32e37887c9551fe822d9ef491ca77d7283f28a750004e96d"
+checksum = "18c35d1130f676aea058ac29aba470041e092e1359be0f9d10ef33bf5a9a91d7"
 dependencies = [
  "blake3",
  "facet",
@@ -4688,9 +4690,9 @@ dependencies = [
 
 [[package]]
 name = "vox-service-macros"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98796a94d18cc3a7f37415798db214f1068c0faf9f2e093e94334a8f81fb0377"
+checksum = "b855b388259d8e60623eef7b8ebc882e5bf694bc2848c275215b95c49e8126b8"
 dependencies = [
  "proc-macro2",
  "vox-macros-core",
@@ -4698,9 +4700,9 @@ dependencies = [
 
 [[package]]
 name = "vox-stream"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bfe52bf2e811869a9fc762e06a253c92749dc41efc621cea65d45a2255e9223"
+checksum = "a3e6285a8488a14cab04f42be24f9af1459703003208e123652db9f9b25df18b"
 dependencies = [
  "moire",
  "tokio",
@@ -4710,9 +4712,9 @@ dependencies = [
 
 [[package]]
 name = "vox-types"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22861e99512412f489f9e1f9041d8d28b320aef8dcf4eb8f3a694d3617bd1e95"
+checksum = "9d8636ebe3c3f685c76091c3a805466aa4efb1c7a6df711c73f99f49016348bc"
 dependencies = [
  "bitflags 2.11.0",
  "blake3",
@@ -4720,6 +4722,7 @@ dependencies = [
  "facet-cbor",
  "facet-core",
  "facet-path",
+ "facet-reflect",
  "futures-channel",
  "heck",
  "indexmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,8 +1459,6 @@ dependencies = [
 [[package]]
 name = "facet-cbor"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51d4c1c7511cf82fadc0eb85e9c97e03751acf8b8cd8ef4954bb5a56d0198a8"
 dependencies = [
  "facet",
  "facet-core",
@@ -2688,8 +2686,7 @@ dependencies = [
 [[package]]
 name = "moire"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac52dcc0ff5b4710a66626370b1bf85ba3d924fd8019e8cfa100e8dafffda4ad"
+source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 dependencies = [
  "moire-macros-noop",
  "moire-tokio",
@@ -2699,14 +2696,12 @@ dependencies = [
 [[package]]
 name = "moire-macros-noop"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ccdc0bf403f5ecf29c09e8e9f178caed89a914ea032e0c2d99d3824b78892d"
+source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 
 [[package]]
 name = "moire-runtime"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568cc05b223c4c76247467e3bdaa7862f05c38d5c8f6e44198613880f90ecd98"
+source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 dependencies = [
  "ctor",
  "facet",
@@ -2722,10 +2717,8 @@ dependencies = [
 [[package]]
 name = "moire-tokio"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb30c43038ce71c727da5a4ff01d09dd4c823486cc17b3b08661420d0ceda43"
+source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 dependencies = [
- "ctor",
  "moire-runtime",
  "moire-types",
  "parking_lot",
@@ -2735,8 +2728,7 @@ dependencies = [
 [[package]]
 name = "moire-trace-capture"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6685ebbdee1253529c9074c41d8288504b640ffe8c21176ce464fef5c5c00c38"
+source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 dependencies = [
  "libc",
  "moire-trace-types",
@@ -2745,8 +2737,7 @@ dependencies = [
 [[package]]
 name = "moire-trace-types"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ef6f98b447211257a517d101f0f5cf4300627cd6fd1c0c13ff53d157a872c9d"
+source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 dependencies = [
  "facet",
 ]
@@ -2754,8 +2745,7 @@ dependencies = [
 [[package]]
 name = "moire-types"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667b2fc41e30d3b0f7d0d29e978d3f473afaf0e0be355202eead317e35ace200"
+source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 dependencies = [
  "facet",
  "facet-value",
@@ -2765,8 +2755,7 @@ dependencies = [
 [[package]]
 name = "moire-wasm"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f143cef34407271acdbca3af106d82b330693e0990ef87df146441392d8a9577"
+source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2781,8 +2770,7 @@ dependencies = [
 [[package]]
 name = "moire-wire"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0ec84eeb2e23a83339cf5edc9d5a3a9ec5849416bd4051951fba416ea3e0f7"
+source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 dependencies = [
  "facet",
  "facet-json",
@@ -4595,8 +4583,6 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vox"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1ea898f15bbd3d1f5e3795470928beb7a80dcdcf7a100d1316d28b56a8bb4b"
 dependencies = [
  "facet",
  "tracing",
@@ -4609,8 +4595,6 @@ dependencies = [
 [[package]]
 name = "vox-core"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1b808eb97ec31e36567caa303f20fac9e745dd6ef19b6b8767478677639b30"
 dependencies = [
  "facet",
  "facet-cbor",
@@ -4631,8 +4615,6 @@ dependencies = [
 [[package]]
 name = "vox-local"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "208a9015db7a855fc202aa5ec31537bb64dd3768eab714300e8c28ada3c4ba09"
 dependencies = [
  "moire",
  "tokio",
@@ -4641,8 +4623,6 @@ dependencies = [
 [[package]]
 name = "vox-macros-core"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9835e61aa64cc2317424af75cda2da516c0ab985cb3ed97be287c2738cf1dad8"
 dependencies = [
  "facet-cargo-toml",
  "heck",
@@ -4654,8 +4634,6 @@ dependencies = [
 [[package]]
 name = "vox-macros-parse"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58da604c34878eec374213d62151862f9794c8595b0615f823ea9c5133f2efc9"
 dependencies = [
  "proc-macro2",
  "unsynn",
@@ -4664,8 +4642,6 @@ dependencies = [
 [[package]]
 name = "vox-postcard"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a2fe5aadbf23e581e0cbf53417dc769992da887e38b36fc2daf9580059b34e"
 dependencies = [
  "facet",
  "facet-core",
@@ -4676,8 +4652,6 @@ dependencies = [
 [[package]]
 name = "vox-schema"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99feee2df54ce8e6378942c2597939afca54b16fbde2e27fafc7563bf3cb6d72"
 dependencies = [
  "blake3",
  "facet",
@@ -4689,8 +4663,6 @@ dependencies = [
 [[package]]
 name = "vox-service-macros"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b10dc949f985bf6c094a9f4ff49cf038d2b6236a83010831253d1c10602d6f"
 dependencies = [
  "proc-macro2",
  "vox-macros-core",
@@ -4699,8 +4671,6 @@ dependencies = [
 [[package]]
 name = "vox-stream"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61908719b4faea59529224d5d5f8a1b46d75c8299c78848eb27fc62112bf054"
 dependencies = [
  "moire",
  "tokio",
@@ -4711,8 +4681,6 @@ dependencies = [
 [[package]]
 name = "vox-types"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93496d65949636e697ad9a2d8e941721a9ed00770750e8cef76c950e72ecd888"
 dependencies = [
  "bitflags 2.11.0",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,8 +1459,7 @@ dependencies = [
 [[package]]
 name = "facet-cbor"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89019be41ea06075e724e3bb18064c201a28c08bddb3616bb26cf9993833bf3"
+source = "git+https://github.com/bearcove/vox.git?rev=b204d069b717e299039b9c32d2860532deb2aa37#b204d069b717e299039b9c32d2860532deb2aa37"
 dependencies = [
  "facet",
  "facet-core",
@@ -2688,8 +2687,7 @@ dependencies = [
 [[package]]
 name = "moire"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac52dcc0ff5b4710a66626370b1bf85ba3d924fd8019e8cfa100e8dafffda4ad"
+source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 dependencies = [
  "moire-macros-noop",
  "moire-tokio",
@@ -2699,14 +2697,12 @@ dependencies = [
 [[package]]
 name = "moire-macros-noop"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ccdc0bf403f5ecf29c09e8e9f178caed89a914ea032e0c2d99d3824b78892d"
+source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 
 [[package]]
 name = "moire-runtime"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568cc05b223c4c76247467e3bdaa7862f05c38d5c8f6e44198613880f90ecd98"
+source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 dependencies = [
  "ctor",
  "facet",
@@ -2722,10 +2718,8 @@ dependencies = [
 [[package]]
 name = "moire-tokio"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb30c43038ce71c727da5a4ff01d09dd4c823486cc17b3b08661420d0ceda43"
+source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 dependencies = [
- "ctor",
  "moire-runtime",
  "moire-types",
  "parking_lot",
@@ -2735,8 +2729,7 @@ dependencies = [
 [[package]]
 name = "moire-trace-capture"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6685ebbdee1253529c9074c41d8288504b640ffe8c21176ce464fef5c5c00c38"
+source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 dependencies = [
  "libc",
  "moire-trace-types",
@@ -2745,8 +2738,7 @@ dependencies = [
 [[package]]
 name = "moire-trace-types"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ef6f98b447211257a517d101f0f5cf4300627cd6fd1c0c13ff53d157a872c9d"
+source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 dependencies = [
  "facet",
 ]
@@ -2754,8 +2746,7 @@ dependencies = [
 [[package]]
 name = "moire-types"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667b2fc41e30d3b0f7d0d29e978d3f473afaf0e0be355202eead317e35ace200"
+source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 dependencies = [
  "facet",
  "facet-value",
@@ -2765,8 +2756,7 @@ dependencies = [
 [[package]]
 name = "moire-wasm"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f143cef34407271acdbca3af106d82b330693e0990ef87df146441392d8a9577"
+source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2781,8 +2771,7 @@ dependencies = [
 [[package]]
 name = "moire-wire"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0ec84eeb2e23a83339cf5edc9d5a3a9ec5849416bd4051951fba416ea3e0f7"
+source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 dependencies = [
  "facet",
  "facet-json",
@@ -4595,8 +4584,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vox"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ae2094aa7173b3c28427ec1d20cebd98f45c22a46e09294b7ce0413bca3cb4b"
+source = "git+https://github.com/bearcove/vox.git?rev=b204d069b717e299039b9c32d2860532deb2aa37#b204d069b717e299039b9c32d2860532deb2aa37"
 dependencies = [
  "facet",
  "facet-pretty",
@@ -4611,8 +4599,7 @@ dependencies = [
 [[package]]
 name = "vox-core"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d3404fab6d551e3890369501ebfaa170ca8b4d973b86eec3ae924e0bb9e8c2"
+source = "git+https://github.com/bearcove/vox.git?rev=b204d069b717e299039b9c32d2860532deb2aa37#b204d069b717e299039b9c32d2860532deb2aa37"
 dependencies = [
  "facet",
  "facet-cbor",
@@ -4633,8 +4620,7 @@ dependencies = [
 [[package]]
 name = "vox-local"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c42e07429c5494b51563192a8a36c2e8396569faaeccdfc77c0fe0600eb881"
+source = "git+https://github.com/bearcove/vox.git?rev=b204d069b717e299039b9c32d2860532deb2aa37#b204d069b717e299039b9c32d2860532deb2aa37"
 dependencies = [
  "moire",
  "tokio",
@@ -4643,8 +4629,7 @@ dependencies = [
 [[package]]
 name = "vox-macros-core"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9047b79fae422b8e1a5d15fe55108bc2a1484aff94662932aa14bcc6ecde1b7e"
+source = "git+https://github.com/bearcove/vox.git?rev=b204d069b717e299039b9c32d2860532deb2aa37#b204d069b717e299039b9c32d2860532deb2aa37"
 dependencies = [
  "facet-cargo-toml",
  "heck",
@@ -4656,8 +4641,7 @@ dependencies = [
 [[package]]
 name = "vox-macros-parse"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f687c5813a5826e900753ec736896bf57997ceb15180bdffc9841f43345901a"
+source = "git+https://github.com/bearcove/vox.git?rev=b204d069b717e299039b9c32d2860532deb2aa37#b204d069b717e299039b9c32d2860532deb2aa37"
 dependencies = [
  "proc-macro2",
  "unsynn",
@@ -4666,8 +4650,7 @@ dependencies = [
 [[package]]
 name = "vox-postcard"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "813a4858832dd8eee753b2a1a3a90d5a03e7a51871e019f23d3979c7a98814f5"
+source = "git+https://github.com/bearcove/vox.git?rev=b204d069b717e299039b9c32d2860532deb2aa37#b204d069b717e299039b9c32d2860532deb2aa37"
 dependencies = [
  "facet",
  "facet-core",
@@ -4678,8 +4661,7 @@ dependencies = [
 [[package]]
 name = "vox-schema"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c35d1130f676aea058ac29aba470041e092e1359be0f9d10ef33bf5a9a91d7"
+source = "git+https://github.com/bearcove/vox.git?rev=b204d069b717e299039b9c32d2860532deb2aa37#b204d069b717e299039b9c32d2860532deb2aa37"
 dependencies = [
  "blake3",
  "facet",
@@ -4691,8 +4673,7 @@ dependencies = [
 [[package]]
 name = "vox-service-macros"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b855b388259d8e60623eef7b8ebc882e5bf694bc2848c275215b95c49e8126b8"
+source = "git+https://github.com/bearcove/vox.git?rev=b204d069b717e299039b9c32d2860532deb2aa37#b204d069b717e299039b9c32d2860532deb2aa37"
 dependencies = [
  "proc-macro2",
  "vox-macros-core",
@@ -4701,8 +4682,7 @@ dependencies = [
 [[package]]
 name = "vox-stream"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e6285a8488a14cab04f42be24f9af1459703003208e123652db9f9b25df18b"
+source = "git+https://github.com/bearcove/vox.git?rev=b204d069b717e299039b9c32d2860532deb2aa37#b204d069b717e299039b9c32d2860532deb2aa37"
 dependencies = [
  "moire",
  "tokio",
@@ -4713,8 +4693,7 @@ dependencies = [
 [[package]]
 name = "vox-types"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8636ebe3c3f685c76091c3a805466aa4efb1c7a6df711c73f99f49016348bc"
+source = "git+https://github.com/bearcove/vox.git?rev=b204d069b717e299039b9c32d2860532deb2aa37#b204d069b717e299039b9c32d2860532deb2aa37"
 dependencies = [
  "bitflags 2.11.0",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,10 +173,10 @@ time = { version = "0.3", features = ["formatting"] }
 tempfile = "3.24.0"
 
 # vox RPC framework
-vox = "0.2.0"
-vox-core = "0.2.0"
-vox-stream = "0.2.0"
-vox-local = "0.2.0"
+vox = { path = "../vox/rust/vox" }
+vox-core = { path = "../vox/rust/vox-core" }
+vox-stream = { path = "../vox/rust/vox-stream" }
+vox-local = { path = "../vox/rust/vox-local" }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,6 +178,9 @@ vox-core = "0.3.0"
 vox-stream = "0.3.0"
 vox-local = "0.3.0"
 
+[profile.release]
+debug = "line-tables-only"
+
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,10 +173,10 @@ time = { version = "0.3", features = ["formatting"] }
 tempfile = "3.24.0"
 
 # vox RPC framework
-vox = "0.2.2"
-vox-core = "0.2.2"
-vox-stream = "0.2.2"
-vox-local = "0.2.2"
+vox = "0.3.0"
+vox-core = "0.3.0"
+vox-stream = "0.3.0"
+vox-local = "0.3.0"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,11 +172,11 @@ facet-typescript = { version = "0.44" }
 time = { version = "0.3", features = ["formatting"] }
 tempfile = "3.24.0"
 
-# roam RPC framework
-roam = "7.0.0"
-roam-core = "7.0.0"
-roam-stream = "7.0.0"
-roam-local = "7.0.0"
+# vox RPC framework
+vox = "0.2.0"
+vox-core = "0.2.0"
+vox-stream = "0.2.0"
+vox-local = "0.2.0"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,10 +173,10 @@ time = { version = "0.3", features = ["formatting"] }
 tempfile = "3.24.0"
 
 # vox RPC framework
-vox = "0.3.0"
-vox-core = "0.3.0"
-vox-stream = "0.3.0"
-vox-local = "0.3.0"
+vox = { git = "https://github.com/bearcove/vox.git", rev = "b204d069b717e299039b9c32d2860532deb2aa37" }
+vox-core = { git = "https://github.com/bearcove/vox.git", rev = "b204d069b717e299039b9c32d2860532deb2aa37" }
+vox-stream = { git = "https://github.com/bearcove/vox.git", rev = "b204d069b717e299039b9c32d2860532deb2aa37" }
+vox-local = { git = "https://github.com/bearcove/vox.git", rev = "b204d069b717e299039b9c32d2860532deb2aa37" }
 
 [profile.release]
 debug = "line-tables-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,10 +173,10 @@ time = { version = "0.3", features = ["formatting"] }
 tempfile = "3.24.0"
 
 # vox RPC framework
-vox = { path = "../vox/rust/vox" }
-vox-core = { path = "../vox/rust/vox-core" }
-vox-stream = { path = "../vox/rust/vox-stream" }
-vox-local = { path = "../vox/rust/vox-local" }
+vox = "0.2.2"
+vox-core = "0.2.2"
+vox-stream = "0.2.2"
+vox-local = "0.2.2"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ tracey web
 
 ## Architecture
 
-Tracey runs as a persistent daemon per workspace. All interfaces (web dashboard, LSP, MCP, CLI queries) connect to the daemon over a Unix socket using [roam](https://github.com/bearcove/roam) RPC.
+Tracey runs as a persistent daemon per workspace. All interfaces (web dashboard, LSP, MCP, CLI queries) connect to the daemon over a Unix socket using [vox](https://github.com/bearcove/vox) RPC.
 
 ```
                     .tracey/daemon.sock

--- a/README.md.in
+++ b/README.md.in
@@ -124,7 +124,7 @@ tracey web
 
 ## Architecture
 
-Tracey runs as a persistent daemon per workspace. All interfaces (web dashboard, LSP, MCP, CLI queries) connect to the daemon over a Unix socket using [roam](https://github.com/bearcove/roam) RPC.
+Tracey runs as a persistent daemon per workspace. All interfaces (web dashboard, LSP, MCP, CLI queries) connect to the daemon over a Unix socket using [vox](https://github.com/bearcove/vox) RPC.
 
 ```
                     .tracey/daemon.sock

--- a/crates/tracey-proto/Cargo.toml
+++ b/crates/tracey-proto/Cargo.toml
@@ -16,8 +16,8 @@ authors.workspace = true
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-# roam RPC framework
-roam = { workspace = true }
+# vox RPC framework
+vox = { workspace = true }
 
 # API types (re-exported for convenience)
 tracey-api = { workspace = true }

--- a/crates/tracey-proto/src/lib.rs
+++ b/crates/tracey-proto/src/lib.rs
@@ -1,12 +1,12 @@
 //! Protocol definitions for the tracey daemon RPC service.
 //!
-//! This crate defines the `TraceyDaemon` service trait using roam's `#[service]`
+//! This crate defines the `TraceyDaemon` service trait using vox's `#[service]`
 //! macro. The daemon exposes this service over a Unix socket, and bridges
 //! (HTTP, MCP, LSP) connect as clients.
 
 use facet::Facet;
-use roam::Tx;
 use tracey_core::RuleId;
+use vox::Tx;
 
 // Re-export API types for convenience
 pub use tracey_api::*;
@@ -640,7 +640,7 @@ pub struct LspDocumentRequest {
 ///
 /// This service is exposed by the daemon over a Unix socket. Bridges (HTTP, MCP, LSP)
 /// connect as clients and translate their protocols to/from these RPC calls.
-#[roam::service]
+#[vox::service]
 pub trait TraceyDaemon {
     // === Core Queries ===
 

--- a/crates/tracey-proto/src/lib.rs
+++ b/crates/tracey-proto/src/lib.rs
@@ -180,6 +180,8 @@ pub struct UnmappedUnit {
 #[derive(Debug, Clone, Facet)]
 #[facet(rename_all = "camelCase")]
 pub struct StatusResponse {
+    #[facet(default)]
+    pub api_schema_version: u32,
     pub impls: Vec<ImplStatus>,
 }
 

--- a/crates/tracey/Cargo.toml
+++ b/crates/tracey/Cargo.toml
@@ -94,10 +94,10 @@ tower-lsp = { workspace = true }
 # Open URLs in browser
 open = { workspace = true }
 
-# roam RPC framework (for daemon architecture)
-roam = { workspace = true }
-roam-stream = { workspace = true }
-roam-local = { workspace = true }
+# vox RPC framework (for daemon architecture)
+vox = { workspace = true }
+vox-stream = { workspace = true }
+vox-local = { workspace = true }
 dirs = { workspace = true }
 
 [features]
@@ -113,4 +113,4 @@ time = { workspace = true, features = ["formatting"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-roam-core = { workspace = true }
+vox-core = { workspace = true }

--- a/crates/tracey/src/bridge/export.rs
+++ b/crates/tracey/src/bridge/export.rs
@@ -23,7 +23,7 @@ pub async fn run(
         None => crate::find_project_root().wrap_err("finding project root")?,
     };
 
-    let client = crate::daemon::new_client(project_root);
+    let client = crate::daemon::new_client(project_root).await?;
     let config = client
         .config()
         .await

--- a/crates/tracey/src/bridge/http/mod.rs
+++ b/crates/tracey/src/bridge/http/mod.rs
@@ -354,9 +354,9 @@ impl ApiError {
     }
 }
 
-/// Convert roam RPC result to Result<T, Response>
+/// Convert vox RPC result to Result<T, Response>
 #[allow(clippy::result_large_err)]
-fn rpc<T, E: std::fmt::Debug>(res: Result<T, roam::RoamError<E>>) -> Result<T, Response> {
+fn rpc<T, E: std::fmt::Debug>(res: Result<T, vox::VoxError<E>>) -> Result<T, Response> {
     res.map_err(|e| ApiError::rpc_error(format!("{:?}", e)))
 }
 

--- a/crates/tracey/src/bridge/http/mod.rs
+++ b/crates/tracey/src/bridge/http/mod.rs
@@ -74,7 +74,7 @@ pub async fn run(
     };
 
     // Create client (connects lazily, auto-reconnects)
-    let client = new_client(project_root.clone());
+    let client = new_client(project_root.clone()).await?;
 
     // In dev mode, start Vite dev server
     let vite_server = if dev {

--- a/crates/tracey/src/bridge/lsp.rs
+++ b/crates/tracey/src/bridge/lsp.rs
@@ -810,27 +810,46 @@ impl Backend {
         project_state: Arc<Mutex<LspProjectState>>,
     ) {
         let mut last_version: Option<u64> = None;
-        let (tx, mut rx) = vox::channel::<DataUpdate>();
-        let subscribe_client = daemon_client.clone();
-        let subscribe_task = tokio::spawn(async move { subscribe_client.subscribe(tx).await });
 
         loop {
             {
                 let state = project_state.lock().unwrap();
                 if !state.roots.contains(&project_root) {
-                    break;
+                    return;
                 }
             }
+
+            let (tx, mut rx) = vox::channel::<DataUpdate>();
+            let subscribe_client = daemon_client.clone();
+            let subscribe_task = tokio::spawn(async move { subscribe_client.subscribe(tx).await });
+
             let next_version =
                 match tokio::time::timeout(Duration::from_millis(500), rx.recv()).await {
                     Ok(Ok(Some(update))) => Some(update.version),
-                    Ok(Ok(None)) => daemon_client.version().await.ok(),
-                    Ok(Err(_)) => daemon_client.version().await.ok(),
-                    Err(_) => daemon_client.version().await.ok(),
+                    Ok(Ok(None)) | Ok(Err(_)) | Err(_) => None,
                 };
 
+            subscribe_task.abort();
+            let _ = subscribe_task.await;
+
             let Some(next_version) = next_version else {
-                tokio::time::sleep(Duration::from_millis(250)).await;
+                let next_version = daemon_client.version().await.ok();
+                let Some(next_version) = next_version else {
+                    tokio::time::sleep(Duration::from_millis(250)).await;
+                    continue;
+                };
+                if last_version == Some(next_version) {
+                    tokio::time::sleep(Duration::from_millis(250)).await;
+                    continue;
+                }
+                last_version = Some(next_version);
+                Self::publish_workspace_diagnostics_with(
+                    &client,
+                    &daemon_client,
+                    &project_root,
+                    &project_state,
+                )
+                .await;
                 continue;
             };
 
@@ -846,9 +865,6 @@ impl Backend {
             )
             .await;
         }
-
-        subscribe_task.abort();
-        let _ = subscribe_task.await;
     }
 
     /// Clear diagnostics for workspace files on startup so clients don't retain stale diagnostics

--- a/crates/tracey/src/bridge/lsp.rs
+++ b/crates/tracey/src/bridge/lsp.rs
@@ -22,8 +22,8 @@ use crate::daemon::{DaemonClient, new_client};
 use tracey_core::{RefVerb, parse_rule_id};
 use tracey_proto::*;
 
-/// Convert roam RPC result to a simple Result
-fn rpc<T, E: std::fmt::Debug>(res: Result<T, roam::RoamError<E>>) -> Result<T, String> {
+/// Convert vox RPC result to a simple Result
+fn rpc<T, E: std::fmt::Debug>(res: Result<T, vox::VoxError<E>>) -> Result<T, String> {
     res.map_err(|e| format!("RPC error: {:?}", e))
 }
 
@@ -664,7 +664,7 @@ impl Backend {
         project_state: Arc<Mutex<LspProjectState>>,
     ) {
         let mut last_version: Option<u64> = None;
-        let (tx, mut rx) = roam::channel::<DataUpdate>();
+        let (tx, mut rx) = vox::channel::<DataUpdate>();
         let subscribe_client = daemon_client.clone();
         let subscribe_task = tokio::spawn(async move { subscribe_client.subscribe(tx).await });
 

--- a/crates/tracey/src/bridge/lsp.rs
+++ b/crates/tracey/src/bridge/lsp.rs
@@ -354,36 +354,67 @@ impl Backend {
             .cloned()
     }
 
-    fn ensure_project_root(&self, root_hint: PathBuf) -> (PathBuf, DaemonClient, bool, bool) {
+    async fn ensure_project_root(
+        &self,
+        root_hint: PathBuf,
+    ) -> Option<(PathBuf, DaemonClient, bool, bool)> {
         let root = crate::find_project_root_from(&root_hint);
+        {
+            let mut state = self.project_state.lock().unwrap();
+            let new_root = state.roots.insert(root.clone());
+            if let Some(daemon_client) = state.daemon_clients.get(&root).cloned() {
+                let should_watch = state.watched_roots.insert(root.clone());
+                return Some((root, daemon_client, should_watch, new_root));
+            }
+        }
+
+        let created_client = match new_client(root.clone()).await {
+            Ok(client) => client,
+            Err(error) => {
+                tracing::warn!(
+                    project_root = %root.display(),
+                    error = %error,
+                    "failed to connect daemon client for project root"
+                );
+                return None;
+            }
+        };
+
         let mut state = self.project_state.lock().unwrap();
         let new_root = state.roots.insert(root.clone());
         let daemon_client = state
             .daemon_clients
             .entry(root.clone())
-            .or_insert_with(|| new_client(root.clone()))
+            .or_insert_with(|| created_client)
             .clone();
         let should_watch = state.watched_roots.insert(root.clone());
-        (root, daemon_client, should_watch, new_root)
+        Some((root, daemon_client, should_watch, new_root))
     }
 
-    fn ensure_project_for_path(&self, path: &Path) -> (PathBuf, DaemonClient, bool, bool) {
+    async fn ensure_project_for_path(
+        &self,
+        path: &Path,
+    ) -> Option<(PathBuf, DaemonClient, bool, bool)> {
         let root = {
             let state = self.project_state.lock().unwrap();
             Self::best_root_for_path(path, &state.roots)
         }
         .unwrap_or_else(|| crate::find_project_root_from(path));
 
-        self.ensure_project_root(root)
+        self.ensure_project_root(root).await
     }
 
-    fn ensure_project_for_uri(&self, uri: &Url) -> Option<(PathBuf, DaemonClient, bool, bool)> {
+    async fn ensure_project_for_uri(
+        &self,
+        uri: &Url,
+    ) -> Option<(PathBuf, DaemonClient, bool, bool)> {
         let path = uri.to_file_path().ok()?;
-        Some(self.ensure_project_for_path(&path))
+        self.ensure_project_for_path(&path).await
     }
 
-    fn project_for_doc_uri(&self, uri: &Url) -> Option<(PathBuf, DaemonClient)> {
-        let (project_root, daemon_client, should_watch, _) = self.ensure_project_for_uri(uri)?;
+    async fn project_for_doc_uri(&self, uri: &Url) -> Option<(PathBuf, DaemonClient)> {
+        let (project_root, daemon_client, should_watch, _) =
+            self.ensure_project_for_uri(uri).await?;
         self.spawn_watcher_if_needed(project_root.clone(), daemon_client.clone(), should_watch);
         Some((project_root, daemon_client))
     }
@@ -475,7 +506,8 @@ impl Backend {
 
     /// Notify daemon that a file was opened.
     async fn notify_vfs_open(&self, uri: &Url, content: &str) {
-        let Some((project_root, daemon_client, should_watch, _)) = self.ensure_project_for_uri(uri)
+        let Some((project_root, daemon_client, should_watch, _)) =
+            self.ensure_project_for_uri(uri).await
         else {
             return;
         };
@@ -494,7 +526,8 @@ impl Backend {
 
     /// Notify daemon that a file changed.
     async fn notify_vfs_change(&self, uri: &Url, content: &str) {
-        let Some((project_root, daemon_client, should_watch, _)) = self.ensure_project_for_uri(uri)
+        let Some((project_root, daemon_client, should_watch, _)) =
+            self.ensure_project_for_uri(uri).await
         else {
             return;
         };
@@ -513,7 +546,8 @@ impl Backend {
 
     /// Notify daemon that a file was closed.
     async fn notify_vfs_close(&self, uri: &Url) {
-        let Some((project_root, daemon_client, should_watch, _)) = self.ensure_project_for_uri(uri)
+        let Some((project_root, daemon_client, should_watch, _)) =
+            self.ensure_project_for_uri(uri).await
         else {
             return;
         };
@@ -535,7 +569,8 @@ impl Backend {
     }
 
     async fn refresh_project_diagnostics_for_uri(&self, uri: &Url) {
-        let Some((project_root, daemon_client, should_watch, _)) = self.ensure_project_for_uri(uri)
+        let Some((project_root, daemon_client, should_watch, _)) =
+            self.ensure_project_for_uri(uri).await
         else {
             return;
         };
@@ -746,7 +781,11 @@ impl Backend {
     }
 
     async fn add_workspace_root(&self, root_hint: PathBuf) {
-        let (project_root, daemon_client, should_watch, _) = self.ensure_project_root(root_hint);
+        let Some((project_root, daemon_client, should_watch, _)) =
+            self.ensure_project_root(root_hint).await
+        else {
+            return;
+        };
         self.clear_workspace_diagnostics_on_startup(&project_root)
             .await;
         self.spawn_watcher_if_needed(project_root, daemon_client, should_watch);
@@ -911,7 +950,7 @@ impl LanguageServer for Backend {
             self.notify_vfs_change(&uri, &content).await;
         }
 
-        if let Some((project_root, _, _, _)) = self.ensure_project_for_uri(&uri)
+        if let Some((project_root, _, _, _)) = self.ensure_project_for_uri(&uri).await
             && Self::is_project_config_uri(&uri, &project_root)
         {
             self.refresh_project_diagnostics_for_uri(&uri).await;
@@ -938,7 +977,7 @@ impl LanguageServer for Backend {
         let Some((path, content)) = self.get_path_and_content(uri) else {
             return Ok(None);
         };
-        let Some((_, daemon_client)) = self.project_for_doc_uri(uri) else {
+        let Some((_, daemon_client)) = self.project_for_doc_uri(uri).await else {
             return Ok(None);
         };
 
@@ -993,7 +1032,7 @@ impl LanguageServer for Backend {
             tracing::debug!(uri = %uri, "hover: no path/content for uri");
             return Ok(None);
         };
-        let Some((project_root, daemon_client)) = self.project_for_doc_uri(uri) else {
+        let Some((project_root, daemon_client)) = self.project_for_doc_uri(uri).await else {
             return Ok(None);
         };
 
@@ -1091,7 +1130,7 @@ impl LanguageServer for Backend {
         let Some((path, content)) = self.get_path_and_content(uri) else {
             return Ok(None);
         };
-        let Some((project_root, daemon_client)) = self.project_for_doc_uri(uri) else {
+        let Some((project_root, daemon_client)) = self.project_for_doc_uri(uri).await else {
             return Ok(None);
         };
 
@@ -1140,7 +1179,7 @@ impl LanguageServer for Backend {
         let Some((path, content)) = self.get_path_and_content(uri) else {
             return Ok(None);
         };
-        let Some((project_root, daemon_client)) = self.project_for_doc_uri(uri) else {
+        let Some((project_root, daemon_client)) = self.project_for_doc_uri(uri).await else {
             return Ok(None);
         };
 
@@ -1189,7 +1228,7 @@ impl LanguageServer for Backend {
         let Some((path, content)) = self.get_path_and_content(uri) else {
             return Ok(None);
         };
-        let Some((project_root, daemon_client)) = self.project_for_doc_uri(uri) else {
+        let Some((project_root, daemon_client)) = self.project_for_doc_uri(uri).await else {
             return Ok(None);
         };
 
@@ -1242,7 +1281,7 @@ impl LanguageServer for Backend {
         let Some((path, content)) = self.get_path_and_content(uri) else {
             return Ok(None);
         };
-        let Some((_, daemon_client)) = self.project_for_doc_uri(uri) else {
+        let Some((_, daemon_client)) = self.project_for_doc_uri(uri).await else {
             return Ok(None);
         };
 
@@ -1290,7 +1329,7 @@ impl LanguageServer for Backend {
         let Some((path, content)) = self.get_path_and_content(uri) else {
             return Ok(None);
         };
-        let Some((_, daemon_client)) = self.project_for_doc_uri(uri) else {
+        let Some((_, daemon_client)) = self.project_for_doc_uri(uri).await else {
             return Ok(None);
         };
 
@@ -1340,7 +1379,11 @@ impl LanguageServer for Backend {
     ) -> LspResult<Option<Vec<SymbolInformation>>> {
         let mut lsp_symbols = Vec::new();
         for root in self.active_roots() {
-            let (project_root, daemon_client, should_watch, _) = self.ensure_project_root(root);
+            let Some((project_root, daemon_client, should_watch, _)) =
+                self.ensure_project_root(root).await
+            else {
+                continue;
+            };
             self.spawn_watcher_if_needed(project_root.clone(), daemon_client.clone(), should_watch);
 
             let Ok(symbols) = rpc(daemon_client
@@ -1392,7 +1435,7 @@ impl LanguageServer for Backend {
         let Some((path, content)) = self.get_path_and_content(uri) else {
             return Ok(None);
         };
-        let Some((_, daemon_client)) = self.project_for_doc_uri(uri) else {
+        let Some((_, daemon_client)) = self.project_for_doc_uri(uri).await else {
             return Ok(None);
         };
 
@@ -1448,11 +1491,14 @@ impl LanguageServer for Backend {
             if args.len() >= 2
                 && let (Some(old_rule), Some(new_rule)) = (args[0].as_str(), args[1].as_str())
             {
-                let scope_root = args
+                let scope_uri = args
                     .get(2)
                     .and_then(|v| v.as_str())
-                    .and_then(|s| Url::parse(s).ok())
-                    .and_then(|uri| self.project_for_doc_uri(&uri).map(|(root, _)| root));
+                    .and_then(|s| Url::parse(s).ok());
+                let scope_root = match scope_uri {
+                    Some(uri) => self.project_for_doc_uri(&uri).await.map(|(root, _)| root),
+                    None => None,
+                };
 
                 self.apply_unknown_requirement_rename(old_rule, new_rule, scope_root)
                     .await?;
@@ -1467,7 +1513,7 @@ impl LanguageServer for Backend {
         let Some((path, content)) = self.get_path_and_content(uri) else {
             return Ok(None);
         };
-        let Some((_, daemon_client)) = self.project_for_doc_uri(uri) else {
+        let Some((_, daemon_client)) = self.project_for_doc_uri(uri).await else {
             return Ok(None);
         };
 
@@ -1517,7 +1563,7 @@ impl LanguageServer for Backend {
         let Some((path, content)) = self.get_path_and_content(uri) else {
             return Ok(None);
         };
-        let Some((_, daemon_client)) = self.project_for_doc_uri(uri) else {
+        let Some((_, daemon_client)) = self.project_for_doc_uri(uri).await else {
             return Ok(None);
         };
 
@@ -1566,7 +1612,7 @@ impl LanguageServer for Backend {
         let Some((path, content)) = self.get_path_and_content(uri) else {
             return Ok(None);
         };
-        let Some((_, daemon_client)) = self.project_for_doc_uri(uri) else {
+        let Some((_, daemon_client)) = self.project_for_doc_uri(uri).await else {
             return Ok(None);
         };
 
@@ -1603,7 +1649,7 @@ impl LanguageServer for Backend {
         let Some((path, content)) = self.get_path_and_content(uri) else {
             return Ok(None);
         };
-        let Some((project_root, daemon_client)) = self.project_for_doc_uri(uri) else {
+        let Some((project_root, daemon_client)) = self.project_for_doc_uri(uri).await else {
             return Ok(None);
         };
 
@@ -1661,7 +1707,7 @@ impl LanguageServer for Backend {
         let Some((path, content)) = self.get_path_and_content(uri) else {
             return Ok(None);
         };
-        let Some((_, daemon_client)) = self.project_for_doc_uri(uri) else {
+        let Some((_, daemon_client)) = self.project_for_doc_uri(uri).await else {
             return Ok(None);
         };
 

--- a/crates/tracey/src/bridge/lsp.rs
+++ b/crates/tracey/src/bridge/lsp.rs
@@ -9,11 +9,13 @@
 use std::collections::{HashMap, HashSet};
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use eyre::Result;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
+use tokio::sync::{Mutex as AsyncMutex, Notify};
 use tower_lsp::jsonrpc::Result as LspResult;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, LspService, Server};
@@ -177,6 +179,7 @@ async fn run_lsp_server(cli_project_root: PathBuf) -> Result<()> {
         roots: HashSet::from([project_root.clone()]),
         daemon_clients: HashMap::new(),
         watched_roots: HashSet::new(),
+        vfs_workers: HashMap::new(),
         files_with_diagnostics: HashMap::new(),
     }));
 
@@ -216,8 +219,45 @@ struct LspProjectState {
     daemon_clients: HashMap<PathBuf, DaemonClient>,
     /// Roots with an active rebuild watcher task.
     watched_roots: HashSet<PathBuf>,
+    /// Per-root VFS sync workers that coalesce latest file state.
+    vfs_workers: HashMap<PathBuf, Arc<VfsSyncWorker>>,
     /// Files currently published with non-empty diagnostics, keyed by project root.
     files_with_diagnostics: HashMap<PathBuf, HashSet<String>>,
+}
+
+enum PendingVfsUpdate {
+    Upsert(String),
+    Close,
+}
+
+#[derive(Default)]
+struct VfsSyncWorker {
+    pending: AsyncMutex<HashMap<String, PendingVfsUpdate>>,
+    notify: Notify,
+    shutdown: AtomicBool,
+}
+
+impl VfsSyncWorker {
+    async fn enqueue(&self, path: String, update: PendingVfsUpdate) {
+        let mut pending = self.pending.lock().await;
+        pending.insert(path, update);
+        drop(pending);
+        self.notify.notify_one();
+    }
+
+    async fn take_pending(&self) -> HashMap<String, PendingVfsUpdate> {
+        let mut pending = self.pending.lock().await;
+        std::mem::take(&mut *pending)
+    }
+
+    fn shutdown(&self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        self.notify.notify_waiters();
+    }
+
+    fn is_shutdown(&self) -> bool {
+        self.shutdown.load(Ordering::SeqCst)
+    }
 }
 
 impl Backend {
@@ -436,6 +476,75 @@ impl Backend {
         ));
     }
 
+    async fn ensure_vfs_worker(
+        &self,
+        project_root: PathBuf,
+        daemon_client: DaemonClient,
+    ) -> Arc<VfsSyncWorker> {
+        let worker = {
+            let mut state = self.project_state.lock().unwrap();
+            if let Some(worker) = state.vfs_workers.get(&project_root).cloned() {
+                return worker;
+            }
+
+            let worker = Arc::new(VfsSyncWorker::default());
+            state
+                .vfs_workers
+                .insert(project_root.clone(), worker.clone());
+            worker
+        };
+
+        tokio::spawn(Self::run_vfs_sync_worker(
+            project_root,
+            daemon_client,
+            worker.clone(),
+        ));
+
+        worker
+    }
+
+    async fn run_vfs_sync_worker(
+        project_root: PathBuf,
+        daemon_client: DaemonClient,
+        worker: Arc<VfsSyncWorker>,
+    ) {
+        loop {
+            let pending = worker.take_pending().await;
+            if pending.is_empty() {
+                if worker.is_shutdown() {
+                    break;
+                }
+                worker.notify.notified().await;
+                continue;
+            }
+
+            for (path, update) in pending {
+                match update {
+                    PendingVfsUpdate::Upsert(content) => {
+                        if let Err(error) = daemon_client.vfs_change(path.clone(), content).await {
+                            tracing::debug!(
+                                project_root = %project_root.display(),
+                                path,
+                                error = ?error,
+                                "failed to sync VFS upsert to daemon"
+                            );
+                        }
+                    }
+                    PendingVfsUpdate::Close => {
+                        if let Err(error) = daemon_client.vfs_close(path.clone()).await {
+                            tracing::debug!(
+                                project_root = %project_root.display(),
+                                path,
+                                error = ?error,
+                                "failed to sync VFS close to daemon"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     async fn apply_unknown_requirement_rename(
         &self,
         old_rule: &str,
@@ -512,14 +621,15 @@ impl Backend {
             return;
         };
         if let Ok(path) = uri.to_file_path() {
-            let path = path.to_string_lossy().into_owned();
-            let content = content.to_string();
-            let bg_client = daemon_client.clone();
-            let bg_path = path.clone();
-            let bg_content = content.clone();
-            tokio::spawn(async move {
-                let _ = bg_client.vfs_open(bg_path, bg_content).await;
-            });
+            let worker = self
+                .ensure_vfs_worker(project_root.clone(), daemon_client.clone())
+                .await;
+            worker
+                .enqueue(
+                    path.to_string_lossy().into_owned(),
+                    PendingVfsUpdate::Upsert(content.to_string()),
+                )
+                .await;
         }
         self.spawn_watcher_if_needed(project_root, daemon_client, should_watch);
     }
@@ -532,14 +642,15 @@ impl Backend {
             return;
         };
         if let Ok(path) = uri.to_file_path() {
-            let path = path.to_string_lossy().into_owned();
-            let content = content.to_string();
-            let bg_client = daemon_client.clone();
-            let bg_path = path.clone();
-            let bg_content = content.clone();
-            tokio::spawn(async move {
-                let _ = bg_client.vfs_change(bg_path, bg_content).await;
-            });
+            let worker = self
+                .ensure_vfs_worker(project_root.clone(), daemon_client.clone())
+                .await;
+            worker
+                .enqueue(
+                    path.to_string_lossy().into_owned(),
+                    PendingVfsUpdate::Upsert(content.to_string()),
+                )
+                .await;
         }
         self.spawn_watcher_if_needed(project_root, daemon_client, should_watch);
     }
@@ -552,12 +663,12 @@ impl Backend {
             return;
         };
         if let Ok(path) = uri.to_file_path() {
-            let path = path.to_string_lossy().into_owned();
-            let bg_client = daemon_client.clone();
-            let bg_path = path.clone();
-            tokio::spawn(async move {
-                let _ = bg_client.vfs_close(bg_path).await;
-            });
+            let worker = self
+                .ensure_vfs_worker(project_root.clone(), daemon_client.clone())
+                .await;
+            worker
+                .enqueue(path.to_string_lossy().into_owned(), PendingVfsUpdate::Close)
+                .await;
         }
         self.spawn_watcher_if_needed(project_root, daemon_client, should_watch);
     }
@@ -793,7 +904,7 @@ impl Backend {
 
     async fn remove_workspace_root(&self, root_hint: PathBuf) {
         let project_root = crate::find_project_root_from(&root_hint);
-        let (files_to_clear, should_restore_default) = {
+        let (files_to_clear, should_restore_default, removed_vfs_worker) = {
             let mut state = self.project_state.lock().unwrap();
             state.roots.remove(&project_root);
             state.watched_roots.remove(&project_root);
@@ -805,8 +916,13 @@ impl Backend {
                 .into_iter()
                 .collect::<Vec<_>>();
             let should_restore_default = state.roots.is_empty();
-            (files, should_restore_default)
+            let removed_vfs_worker = state.vfs_workers.remove(&project_root);
+            (files, should_restore_default, removed_vfs_worker)
         };
+
+        if let Some(worker) = removed_vfs_worker {
+            worker.shutdown();
+        }
 
         for path in files_to_clear {
             let Ok(uri) = Url::from_file_path(path) else {
@@ -1868,5 +1984,36 @@ mod tests {
             extract_root_from_initialize(&bytes),
             Some(PathBuf::from("/preferred/root"))
         );
+    }
+
+    #[tokio::test]
+    async fn vfs_worker_keeps_only_latest_update_per_path() {
+        let worker = VfsSyncWorker::default();
+        worker
+            .enqueue(
+                "/tmp/file.rs".to_string(),
+                PendingVfsUpdate::Upsert("first".to_string()),
+            )
+            .await;
+        worker
+            .enqueue(
+                "/tmp/file.rs".to_string(),
+                PendingVfsUpdate::Upsert("second".to_string()),
+            )
+            .await;
+        worker
+            .enqueue("/tmp/other.rs".to_string(), PendingVfsUpdate::Close)
+            .await;
+
+        let pending = worker.take_pending().await;
+        assert_eq!(pending.len(), 2);
+        match pending.get("/tmp/file.rs") {
+            Some(PendingVfsUpdate::Upsert(content)) => assert_eq!(content, "second"),
+            _ => panic!("expected latest upsert for /tmp/file.rs"),
+        }
+        assert!(matches!(
+            pending.get("/tmp/other.rs"),
+            Some(PendingVfsUpdate::Close)
+        ));
     }
 }

--- a/crates/tracey/src/bridge/lsp.rs
+++ b/crates/tracey/src/bridge/lsp.rs
@@ -809,54 +809,47 @@ impl Backend {
         project_root: PathBuf,
         project_state: Arc<Mutex<LspProjectState>>,
     ) {
-        let mut last_version: Option<u64> = None;
+        let mut reconnect_backoff = Duration::from_millis(250);
+        let mut updates_rx = None;
+
+        let root_is_active = |state: &Arc<Mutex<LspProjectState>>, root: &PathBuf| {
+            let guard = state.lock().unwrap();
+            guard.roots.contains(root)
+        };
 
         loop {
-            {
-                let state = project_state.lock().unwrap();
-                if !state.roots.contains(&project_root) {
-                    return;
-                }
+            if !root_is_active(&project_state, &project_root) {
+                return;
             }
 
-            let (tx, mut rx) = vox::channel::<DataUpdate>();
-            let subscribe_client = daemon_client.clone();
-            let subscribe_task = tokio::spawn(async move { subscribe_client.subscribe(tx).await });
-
-            let next_version =
-                match tokio::time::timeout(Duration::from_millis(500), rx.recv()).await {
-                    Ok(Ok(Some(update))) => Some(update.version),
-                    Ok(Ok(None)) | Ok(Err(_)) | Err(_) => None,
-                };
-
-            subscribe_task.abort();
-            let _ = subscribe_task.await;
-
-            let Some(next_version) = next_version else {
-                let next_version = daemon_client.version().await.ok();
-                let Some(next_version) = next_version else {
-                    tokio::time::sleep(Duration::from_millis(250)).await;
-                    continue;
-                };
-                if last_version == Some(next_version) {
-                    tokio::time::sleep(Duration::from_millis(250)).await;
+            if updates_rx.is_none() {
+                let (tx, rx) = vox::channel::<DataUpdate>();
+                if let Err(error) = daemon_client.subscribe(tx).await {
+                    tracing::debug!(
+                        project_root = %project_root.display(),
+                        error = ?error,
+                        "lsp rebuild subscription failed; will retry"
+                    );
+                    tokio::time::sleep(reconnect_backoff).await;
+                    reconnect_backoff = (reconnect_backoff * 2).min(Duration::from_secs(4));
                     continue;
                 }
-                last_version = Some(next_version);
-                Self::publish_workspace_diagnostics_with(
-                    &client,
-                    &daemon_client,
-                    &project_root,
-                    &project_state,
-                )
+                updates_rx = Some(rx);
+                reconnect_backoff = Duration::from_millis(250);
+            }
+
+            let recv = updates_rx
+                .as_mut()
+                .expect("receiver is initialized before receive")
+                .recv()
                 .await;
+            let Ok(Some(_update)) = recv else {
+                updates_rx = None;
+                tokio::time::sleep(reconnect_backoff).await;
+                reconnect_backoff = (reconnect_backoff * 2).min(Duration::from_secs(4));
                 continue;
             };
 
-            if last_version == Some(next_version) {
-                continue;
-            }
-            last_version = Some(next_version);
             Self::publish_workspace_diagnostics_with(
                 &client,
                 &daemon_client,

--- a/crates/tracey/src/bridge/mcp.rs
+++ b/crates/tracey/src/bridge/mcp.rs
@@ -8,6 +8,7 @@
 
 #![allow(clippy::enum_variant_names)]
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -296,6 +297,7 @@ struct TraceyHandler {
     startup_project_root: PathBuf,
     config_path: PathBuf,
     active_project_root: Arc<RwLock<PathBuf>>,
+    clients_by_root: Arc<RwLock<HashMap<PathBuf, query::QueryClient>>>,
     root_refresh_state: Arc<RwLock<RootRefreshState>>,
     trace_sink: Option<McpTraceSink>,
 }
@@ -316,6 +318,7 @@ impl TraceyHandler {
             startup_project_root: project_root.clone(),
             config_path,
             active_project_root: Arc::new(RwLock::new(project_root)),
+            clients_by_root: Arc::new(RwLock::new(HashMap::new())),
             root_refresh_state: Arc::new(RwLock::new(RootRefreshState::default())),
             trace_sink,
         };
@@ -332,9 +335,14 @@ impl TraceyHandler {
         handler
     }
 
-    async fn current_client(&self) -> query::QueryClient {
-        let root = self.active_project_root.read().await.clone();
-        query::QueryClient::new(root, query::Caller::Mcp)
+    async fn current_client(&self, root: PathBuf) -> Result<query::QueryClient, std::io::Error> {
+        if let Some(client) = self.clients_by_root.read().await.get(&root).cloned() {
+            return Ok(client);
+        }
+
+        let client = query::QueryClient::new(root.clone(), query::Caller::Mcp).await?;
+        let mut clients = self.clients_by_root.write().await;
+        Ok(clients.entry(root).or_insert_with(|| client).clone())
     }
 
     fn trace_json(&self, event: &str, payload: JsonValue) {
@@ -588,7 +596,10 @@ impl ServerHandler for TraceyHandler {
                 "project_root": project_root.display().to_string(),
             }),
         );
-        let client = self.current_client().await;
+        let client = self
+            .current_client(project_root)
+            .await
+            .map_err(|e| CallToolError(Box::new(e)))?;
 
         let mut response = match tool_name.as_str() {
             "tracey_status" => client.status().await,

--- a/crates/tracey/src/bridge/mod.rs
+++ b/crates/tracey/src/bridge/mod.rs
@@ -1,7 +1,7 @@
 //! Protocol bridges to the tracey daemon.
 //!
 //! Each bridge translates a specific protocol (HTTP, LSP, MCP) to the
-//! daemon's roam RPC interface. Bridges are thin protocol adapters that
+//! daemon's vox RPC interface. Bridges are thin protocol adapters that
 //! connect as clients to the daemon.
 
 pub mod export;

--- a/crates/tracey/src/bridge/query.rs
+++ b/crates/tracey/src/bridge/query.rs
@@ -3,6 +3,7 @@
 //! This module contains the actual query-to-client formatting logic so both
 //! MCP and terminal queries print the same markdown-like output.
 
+use std::io;
 use std::path::PathBuf;
 use std::{collections::BTreeMap, collections::BTreeSet};
 
@@ -111,11 +112,11 @@ pub struct QueryClient {
 }
 
 impl QueryClient {
-    pub fn new(project_root: PathBuf, caller: Caller) -> Self {
-        Self {
-            client: new_client(project_root),
+    pub async fn new(project_root: PathBuf, caller: Caller) -> io::Result<Self> {
+        Ok(Self {
+            client: new_client(project_root).await?,
             caller,
-        }
+        })
     }
 
     /// Check for config errors and return a warning banner if present.

--- a/crates/tracey/src/daemon/client.rs
+++ b/crates/tracey/src/daemon/client.rs
@@ -1,6 +1,6 @@
 //! Client for connecting to the tracey daemon.
 //!
-//! Uses roam v7 session builders.
+//! Uses vox session builders.
 
 use std::fs::OpenOptions;
 use std::future::Future;
@@ -26,7 +26,7 @@ pub fn new_client(project_root: PathBuf) -> DaemonClient {
 }
 
 impl DaemonClient {
-    async fn connect_inner(&self) -> io::Result<roam_stream::LocalLink> {
+    async fn connect_inner(&self) -> io::Result<vox_stream::LocalLink> {
         let start = Instant::now();
         debug!(
             project_root = %self.project_root.display(),
@@ -41,10 +41,10 @@ impl DaemonClient {
         Ok(stream)
     }
 
-    async fn with_client<T, E, F, Fut>(&self, f: F) -> Result<T, roam::RoamError<E>>
+    async fn with_client<T, E, F, Fut>(&self, f: F) -> Result<T, vox::VoxError<E>>
     where
         F: FnOnce(TraceyDaemonClient) -> Fut,
-        Fut: Future<Output = Result<T, roam::RoamError<E>>>,
+        Fut: Future<Output = Result<T, vox::VoxError<E>>>,
     {
         let start = Instant::now();
         let callsite = std::panic::Location::caller();
@@ -61,10 +61,10 @@ impl DaemonClient {
                     callsite = format_args!("{}:{}", callsite.file(), callsite.line()),
                     "daemon client: connect_inner failed"
                 );
-                return Err(roam::RoamError::Cancelled);
+                return Err(vox::VoxError::Cancelled);
             }
         };
-        let (client, _session_handle) = match roam::initiator(stream)
+        let (client, _session_handle) = match vox::initiator_on(stream, vox::TransportMode::Bare)
             .establish::<TraceyDaemonClient>(())
             .await
         {
@@ -72,7 +72,7 @@ impl DaemonClient {
                 debug!(
                     elapsed_ms = start.elapsed().as_millis(),
                     callsite = format_args!("{}:{}", callsite.file(), callsite.line()),
-                    "daemon client: roam session established"
+                    "daemon client: vox session established"
                 );
                 parts
             }
@@ -81,9 +81,9 @@ impl DaemonClient {
                     elapsed_ms = start.elapsed().as_millis(),
                     error = %e,
                     callsite = format_args!("{}:{}", callsite.file(), callsite.line()),
-                    "daemon client: roam session establish failed"
+                    "daemon client: vox session establish failed"
                 );
-                return Err(roam::RoamError::Cancelled);
+                return Err(vox::VoxError::Cancelled);
             }
         };
         let result = f(client).await;
@@ -99,83 +99,83 @@ impl DaemonClient {
                 warn!(
                     elapsed_ms = start.elapsed().as_millis(),
                     callsite = format_args!("{}:{}", callsite.file(), callsite.line()),
-                    "daemon client: with_client returned roam error"
+                    "daemon client: with_client returned vox error"
                 );
             }
         }
         result
     }
 
-    pub async fn status(&self) -> Result<tracey_proto::StatusResponse, roam::RoamError> {
+    pub async fn status(&self) -> Result<tracey_proto::StatusResponse, vox::VoxError> {
         self.with_client(|c| async move { c.status().await }).await
     }
     pub async fn uncovered(
         &self,
         req: tracey_proto::UncoveredRequest,
-    ) -> Result<tracey_proto::UncoveredResponse, roam::RoamError> {
+    ) -> Result<tracey_proto::UncoveredResponse, vox::VoxError> {
         self.with_client(|c| async move { c.uncovered(req).await })
             .await
     }
     pub async fn untested(
         &self,
         req: tracey_proto::UntestedRequest,
-    ) -> Result<tracey_proto::UntestedResponse, roam::RoamError> {
+    ) -> Result<tracey_proto::UntestedResponse, vox::VoxError> {
         self.with_client(|c| async move { c.untested(req).await })
             .await
     }
     pub async fn stale(
         &self,
         req: tracey_proto::StaleRequest,
-    ) -> Result<tracey_proto::StaleResponse, roam::RoamError> {
+    ) -> Result<tracey_proto::StaleResponse, vox::VoxError> {
         self.with_client(|c| async move { c.stale(req).await })
             .await
     }
     pub async fn unmapped(
         &self,
         req: tracey_proto::UnmappedRequest,
-    ) -> Result<tracey_proto::UnmappedResponse, roam::RoamError> {
+    ) -> Result<tracey_proto::UnmappedResponse, vox::VoxError> {
         self.with_client(|c| async move { c.unmapped(req).await })
             .await
     }
     pub async fn rule(
         &self,
         rule_id: tracey_core::RuleId,
-    ) -> Result<Option<tracey_proto::RuleInfo>, roam::RoamError> {
+    ) -> Result<Option<tracey_proto::RuleInfo>, vox::VoxError> {
         self.with_client(|c| async move { c.rule(rule_id).await })
             .await
     }
-    pub async fn config(&self) -> Result<tracey_api::ApiConfig, roam::RoamError> {
+    pub async fn config(&self) -> Result<tracey_api::ApiConfig, vox::VoxError> {
         self.with_client(|c| async move { c.config().await }).await
     }
-    pub async fn vfs_open(&self, path: String, content: String) -> Result<(), roam::RoamError> {
+    pub async fn vfs_open(&self, path: String, content: String) -> Result<(), vox::VoxError> {
         self.with_client(|c| async move { c.vfs_open(path, content).await })
             .await
     }
-    pub async fn vfs_change(&self, path: String, content: String) -> Result<(), roam::RoamError> {
+    pub async fn vfs_change(&self, path: String, content: String) -> Result<(), vox::VoxError> {
         self.with_client(|c| async move { c.vfs_change(path, content).await })
             .await
     }
-    pub async fn vfs_close(&self, path: String) -> Result<(), roam::RoamError> {
+    pub async fn vfs_close(&self, path: String) -> Result<(), vox::VoxError> {
         self.with_client(|c| async move { c.vfs_close(path).await })
             .await
     }
-    pub async fn reload(&self) -> Result<tracey_proto::ReloadResponse, roam::RoamError> {
+    pub async fn reload(&self) -> Result<tracey_proto::ReloadResponse, vox::VoxError> {
         self.with_client(|c| async move { c.reload().await }).await
     }
-    pub async fn version(&self) -> Result<u64, roam::RoamError> {
+    pub async fn version(&self) -> Result<u64, vox::VoxError> {
         self.with_client(|c| async move { c.version().await }).await
     }
-    pub async fn health(&self) -> Result<tracey_proto::HealthResponse, roam::RoamError> {
+    pub async fn health(&self) -> Result<tracey_proto::HealthResponse, vox::VoxError> {
         self.with_client(|c| async move { c.health().await }).await
     }
-    pub async fn shutdown(&self) -> Result<(), roam::RoamError> {
+    pub async fn shutdown(&self) -> Result<(), vox::VoxError> {
         self.with_client(|c| async move { c.shutdown().await })
             .await
     }
     pub async fn subscribe(
         &self,
-        updates: roam::Tx<tracey_proto::DataUpdate>,
-    ) -> Result<(), roam::RoamError> {
+        updates: vox::Tx<tracey_proto::DataUpdate>,
+    ) -> Result<(), vox::VoxError> {
         self.with_client(|c| async move { c.subscribe(updates).await })
             .await
     }
@@ -183,7 +183,7 @@ impl DaemonClient {
         &self,
         spec: String,
         impl_name: String,
-    ) -> Result<Option<tracey_api::ApiSpecForward>, roam::RoamError> {
+    ) -> Result<Option<tracey_api::ApiSpecForward>, vox::VoxError> {
         self.with_client(|c| async move { c.forward(spec, impl_name).await })
             .await
     }
@@ -191,21 +191,21 @@ impl DaemonClient {
         &self,
         spec: String,
         impl_name: String,
-    ) -> Result<Option<tracey_api::ApiReverseData>, roam::RoamError> {
+    ) -> Result<Option<tracey_api::ApiReverseData>, vox::VoxError> {
         self.with_client(|c| async move { c.reverse(spec, impl_name).await })
             .await
     }
     pub async fn file(
         &self,
         req: tracey_proto::FileRequest,
-    ) -> Result<Option<tracey_api::ApiFileData>, roam::RoamError> {
+    ) -> Result<Option<tracey_api::ApiFileData>, vox::VoxError> {
         self.with_client(|c| async move { c.file(req).await }).await
     }
     pub async fn spec_content(
         &self,
         spec: String,
         impl_name: String,
-    ) -> Result<Option<tracey_api::ApiSpecData>, roam::RoamError> {
+    ) -> Result<Option<tracey_api::ApiSpecData>, vox::VoxError> {
         self.with_client(|c| async move { c.spec_content(spec, impl_name).await })
             .await
     }
@@ -213,143 +213,143 @@ impl DaemonClient {
         &self,
         query: String,
         limit: u32,
-    ) -> Result<Vec<tracey_proto::SearchResult>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::SearchResult>, vox::VoxError> {
         self.with_client(|c| async move { c.search(query, limit).await })
             .await
     }
     pub async fn update_file_range(
         &self,
         req: tracey_proto::UpdateFileRangeRequest,
-    ) -> Result<(), roam::RoamError<tracey_proto::UpdateError>> {
+    ) -> Result<(), vox::VoxError<tracey_proto::UpdateError>> {
         self.with_client(|c| async move { c.update_file_range(req).await })
             .await
     }
-    pub async fn is_test_file(&self, path: String) -> Result<bool, roam::RoamError> {
+    pub async fn is_test_file(&self, path: String) -> Result<bool, vox::VoxError> {
         self.with_client(|c| async move { c.is_test_file(path).await })
             .await
     }
     pub async fn lsp_hover(
         &self,
         req: tracey_proto::LspPositionRequest,
-    ) -> Result<Option<tracey_proto::HoverInfo>, roam::RoamError> {
+    ) -> Result<Option<tracey_proto::HoverInfo>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_hover(req).await })
             .await
     }
     pub async fn lsp_definition(
         &self,
         req: tracey_proto::LspPositionRequest,
-    ) -> Result<Vec<tracey_proto::LspLocation>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspLocation>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_definition(req).await })
             .await
     }
     pub async fn lsp_implementation(
         &self,
         req: tracey_proto::LspPositionRequest,
-    ) -> Result<Vec<tracey_proto::LspLocation>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspLocation>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_implementation(req).await })
             .await
     }
     pub async fn lsp_references(
         &self,
         req: tracey_proto::LspReferencesRequest,
-    ) -> Result<Vec<tracey_proto::LspLocation>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspLocation>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_references(req).await })
             .await
     }
     pub async fn lsp_completions(
         &self,
         req: tracey_proto::LspPositionRequest,
-    ) -> Result<Vec<tracey_proto::LspCompletionItem>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspCompletionItem>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_completions(req).await })
             .await
     }
     pub async fn lsp_workspace_diagnostics(
         &self,
-    ) -> Result<Vec<tracey_proto::LspFileDiagnostics>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspFileDiagnostics>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_workspace_diagnostics().await })
             .await
     }
     pub async fn lsp_document_symbols(
         &self,
         req: tracey_proto::LspDocumentRequest,
-    ) -> Result<Vec<tracey_proto::LspSymbol>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspSymbol>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_document_symbols(req).await })
             .await
     }
     pub async fn lsp_workspace_symbols(
         &self,
         query: String,
-    ) -> Result<Vec<tracey_proto::LspSymbol>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspSymbol>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_workspace_symbols(query).await })
             .await
     }
     pub async fn lsp_semantic_tokens(
         &self,
         req: tracey_proto::LspDocumentRequest,
-    ) -> Result<Vec<tracey_proto::LspSemanticToken>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspSemanticToken>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_semantic_tokens(req).await })
             .await
     }
     pub async fn lsp_code_lens(
         &self,
         req: tracey_proto::LspDocumentRequest,
-    ) -> Result<Vec<tracey_proto::LspCodeLens>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspCodeLens>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_code_lens(req).await })
             .await
     }
     pub async fn lsp_inlay_hints(
         &self,
         req: tracey_proto::InlayHintsRequest,
-    ) -> Result<Vec<tracey_proto::LspInlayHint>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspInlayHint>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_inlay_hints(req).await })
             .await
     }
     pub async fn lsp_prepare_rename(
         &self,
         req: tracey_proto::LspPositionRequest,
-    ) -> Result<Option<tracey_proto::PrepareRenameResult>, roam::RoamError> {
+    ) -> Result<Option<tracey_proto::PrepareRenameResult>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_prepare_rename(req).await })
             .await
     }
     pub async fn lsp_rename(
         &self,
         req: tracey_proto::LspRenameRequest,
-    ) -> Result<Vec<tracey_proto::LspTextEdit>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspTextEdit>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_rename(req).await })
             .await
     }
     pub async fn lsp_code_actions(
         &self,
         req: tracey_proto::LspPositionRequest,
-    ) -> Result<Vec<tracey_proto::LspCodeAction>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspCodeAction>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_code_actions(req).await })
             .await
     }
     pub async fn lsp_document_highlight(
         &self,
         req: tracey_proto::LspPositionRequest,
-    ) -> Result<Vec<tracey_proto::LspLocation>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspLocation>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_document_highlight(req).await })
             .await
     }
     pub async fn validate(
         &self,
         req: tracey_proto::ValidateRequest,
-    ) -> Result<tracey_api::ValidationResult, roam::RoamError> {
+    ) -> Result<tracey_api::ValidationResult, vox::VoxError> {
         self.with_client(|c| async move { c.validate(req).await })
             .await
     }
     pub async fn config_add_exclude(
         &self,
         req: tracey_proto::ConfigPatternRequest,
-    ) -> Result<(), roam::RoamError<String>> {
+    ) -> Result<(), vox::VoxError<String>> {
         self.with_client(|c| async move { c.config_add_exclude(req).await })
             .await
     }
     pub async fn config_add_include(
         &self,
         req: tracey_proto::ConfigPatternRequest,
-    ) -> Result<(), roam::RoamError<String>> {
+    ) -> Result<(), vox::VoxError<String>> {
         self.with_client(|c| async move { c.config_add_include(req).await })
             .await
     }
@@ -383,7 +383,7 @@ impl DaemonConnector {
         pid: u32,
         endpoint: &str,
         timeout: Duration,
-    ) -> io::Result<Option<roam_stream::LocalLink>> {
+    ) -> io::Result<Option<vox_stream::LocalLink>> {
         let start = Instant::now();
         let mut last_error: Option<String> = None;
 
@@ -396,7 +396,7 @@ impl DaemonConnector {
                 return Ok(None);
             }
 
-            match roam_stream::LocalLink::connect(&endpoint).await {
+            match vox_stream::LocalLink::connect(&endpoint).await {
                 Ok(stream) => return Ok(Some(stream)),
                 Err(e) => {
                     last_error = Some(e.to_string());
@@ -511,7 +511,7 @@ impl DaemonConnector {
     }
 
     /// Wait for the daemon endpoint to appear and connect.
-    async fn wait_and_connect(&self) -> io::Result<roam_stream::LocalLink> {
+    async fn wait_and_connect(&self) -> io::Result<vox_stream::LocalLink> {
         let endpoint = local_endpoint(&self.project_root);
         let start = Instant::now();
         let timeout = Duration::from_secs(5);
@@ -534,7 +534,7 @@ impl DaemonConnector {
                 ));
             }
 
-            match roam_stream::LocalLink::connect(&endpoint).await {
+            match vox_stream::LocalLink::connect(&endpoint).await {
                 Ok(stream) => return Ok(stream),
                 Err(e) => {
                     last_connect_error = Some(e.to_string());
@@ -580,7 +580,7 @@ fn kill_pid(pid: u32) {
 fn kill_pid(_pid: u32) {}
 
 impl DaemonConnector {
-    pub async fn connect(&self) -> io::Result<roam_stream::LocalLink> {
+    pub async fn connect(&self) -> io::Result<vox_stream::LocalLink> {
         let endpoint = local_endpoint(&self.project_root);
         debug!(
             "DaemonConnector::connect project_root={} endpoint={:?}",
@@ -599,7 +599,7 @@ impl DaemonConnector {
 
                 if alive && version_ok {
                     // Happy path: daemon should be running.
-                    match roam_stream::LocalLink::connect(&endpoint).await {
+                    match vox_stream::LocalLink::connect(&endpoint).await {
                         Ok(stream) => return Ok(stream),
                         Err(e) => {
                             let age = pid_file_age(&self.project_root);
@@ -627,7 +627,7 @@ impl DaemonConnector {
                         }
                     }
                     // Socket connect failed despite live PID — stale socket.
-                    let _ = roam_local::remove_endpoint(&endpoint);
+                    let _ = vox_local::remove_endpoint(&endpoint);
                     let _ = std::fs::remove_file(pid_file_path(&self.project_root));
                 } else {
                     // Kill if alive but wrong version, then clean up.
@@ -639,7 +639,7 @@ impl DaemonConnector {
                         );
                         kill_pid(pid);
                     }
-                    let _ = roam_local::remove_endpoint(&endpoint);
+                    let _ = vox_local::remove_endpoint(&endpoint);
                     let _ = std::fs::remove_file(pid_file_path(&self.project_root));
                 }
             }
@@ -647,12 +647,12 @@ impl DaemonConnector {
                 debug!("No PID file found for {}", self.project_root.display());
                 // No PID file — remove stale socket if present.
                 // r[impl daemon.lifecycle.stale-socket]
-                if roam_local::endpoint_exists(&endpoint) {
+                if vox_local::endpoint_exists(&endpoint) {
                     warn!(
                         "No PID file but endpoint exists at {:?}; removing stale endpoint",
                         endpoint
                     );
-                    let _ = roam_local::remove_endpoint(&endpoint);
+                    let _ = vox_local::remove_endpoint(&endpoint);
                 }
             }
         }
@@ -665,7 +665,7 @@ impl DaemonConnector {
         if let Some((pid, version)) = read_pid_file(&self.project_root)
             && is_pid_alive(pid)
             && version == tracey_proto::PROTOCOL_VERSION
-            && let Ok(stream) = roam_stream::LocalLink::connect(&endpoint).await
+            && let Ok(stream) = vox_stream::LocalLink::connect(&endpoint).await
         {
             debug!(
                 "Daemon became available while waiting for startup lock (pid={})",

--- a/crates/tracey/src/daemon/client.rs
+++ b/crates/tracey/src/daemon/client.rs
@@ -1,9 +1,8 @@
 //! Client for connecting to the tracey daemon.
 //!
-//! Uses vox session builders.
+//! Uses vox session builders with automatic reconnect/retry behavior.
 
 use std::fs::OpenOptions;
-use std::future::Future;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
@@ -14,344 +13,64 @@ use super::{is_pid_alive, local_endpoint, pid_file_path, read_pid_file_at};
 // Re-export the generated client from tracey-proto
 pub use tracey_proto::TraceyDaemonClient;
 
-/// Daemon client facade.
-#[derive(Clone)]
-pub struct DaemonClient {
-    project_root: PathBuf,
+/// Type alias so bridges don't need to know about the generated type name.
+pub type DaemonClient = TraceyDaemonClient;
+
+/// Connect to the tracey daemon, auto-starting it if necessary.
+///
+/// The returned client reconnects automatically when the daemon restarts.
+pub async fn new_client(project_root: PathBuf) -> io::Result<DaemonClient> {
+    let connector = DaemonConnector::new(project_root);
+    let source = DaemonLinkSource {
+        connector,
+        link_attempt: 0,
+    };
+    let (client, _session_handle) = vox::initiator(source, vox::TransportMode::Bare)
+        .establish::<TraceyDaemonClient>(())
+        .await
+        .map_err(|e| io::Error::other(format!("session establish failed: {e}")))?;
+    Ok(client)
 }
 
-/// Create a new daemon client for the given project root.
-pub fn new_client(project_root: PathBuf) -> DaemonClient {
-    DaemonClient { project_root }
+/// Link source that connects to the tracey daemon via local IPC.
+///
+/// Used by vox's source initiator to obtain new links when the
+/// current session attachment drops.
+struct DaemonLinkSource {
+    connector: DaemonConnector,
+    link_attempt: u64,
 }
 
-impl DaemonClient {
-    async fn connect_inner(&self) -> io::Result<vox_stream::LocalLink> {
-        let start = Instant::now();
-        debug!(
-            project_root = %self.project_root.display(),
-            "daemon client: connect_inner start"
-        );
-        let connector = DaemonConnector::new(self.project_root.clone());
-        let stream = connector.connect().await?;
-        debug!(
-            elapsed_ms = start.elapsed().as_millis(),
-            "daemon client: local transport connected"
-        );
-        Ok(stream)
-    }
+impl vox::LinkSource for DaemonLinkSource {
+    type Link = vox_stream::LocalLink;
 
-    async fn with_client<T, E, F, Fut>(&self, f: F) -> Result<T, vox::VoxError<E>>
-    where
-        F: FnOnce(TraceyDaemonClient) -> Fut,
-        Fut: Future<Output = Result<T, vox::VoxError<E>>>,
-    {
-        let start = Instant::now();
-        let callsite = std::panic::Location::caller();
+    async fn next_link(&mut self) -> io::Result<vox::Attachment<vox_stream::LocalLink>> {
+        self.link_attempt = self.link_attempt.wrapping_add(1);
+        let attempt = self.link_attempt;
         debug!(
-            callsite = format_args!("{}:{}", callsite.file(), callsite.line()),
-            "daemon client: with_client start"
+            attempt,
+            project_root = %self.connector.project_root.display(),
+            "Daemon client requesting link"
         );
-        let stream = match self.connect_inner().await {
-            Ok(stream) => stream,
-            Err(e) => {
+        match self.connector.connect().await {
+            Ok(link) => {
+                info!(
+                    attempt,
+                    project_root = %self.connector.project_root.display(),
+                    "Daemon client link ready"
+                );
+                Ok(vox::Attachment::initiator(link))
+            }
+            Err(error) => {
                 warn!(
-                    elapsed_ms = start.elapsed().as_millis(),
-                    error = %e,
-                    callsite = format_args!("{}:{}", callsite.file(), callsite.line()),
-                    "daemon client: connect_inner failed"
+                    attempt,
+                    project_root = %self.connector.project_root.display(),
+                    error = %error,
+                    "Daemon client link attempt failed"
                 );
-                return Err(vox::VoxError::Cancelled);
-            }
-        };
-        let (client, _session_handle) = match vox::initiator_on(stream, vox::TransportMode::Bare)
-            .establish::<TraceyDaemonClient>(())
-            .await
-        {
-            Ok(parts) => {
-                debug!(
-                    elapsed_ms = start.elapsed().as_millis(),
-                    callsite = format_args!("{}:{}", callsite.file(), callsite.line()),
-                    "daemon client: vox session established"
-                );
-                parts
-            }
-            Err(e) => {
-                warn!(
-                    elapsed_ms = start.elapsed().as_millis(),
-                    error = %e,
-                    callsite = format_args!("{}:{}", callsite.file(), callsite.line()),
-                    "daemon client: vox session establish failed"
-                );
-                return Err(vox::VoxError::Cancelled);
-            }
-        };
-        let result = f(client).await;
-        match &result {
-            Ok(_) => {
-                debug!(
-                    elapsed_ms = start.elapsed().as_millis(),
-                    callsite = format_args!("{}:{}", callsite.file(), callsite.line()),
-                    "daemon client: with_client ok"
-                );
-            }
-            Err(_e) => {
-                warn!(
-                    elapsed_ms = start.elapsed().as_millis(),
-                    callsite = format_args!("{}:{}", callsite.file(), callsite.line()),
-                    "daemon client: with_client returned vox error"
-                );
+                Err(error)
             }
         }
-        result
-    }
-
-    pub async fn status(&self) -> Result<tracey_proto::StatusResponse, vox::VoxError> {
-        self.with_client(|c| async move { c.status().await }).await
-    }
-    pub async fn uncovered(
-        &self,
-        req: tracey_proto::UncoveredRequest,
-    ) -> Result<tracey_proto::UncoveredResponse, vox::VoxError> {
-        self.with_client(|c| async move { c.uncovered(req).await })
-            .await
-    }
-    pub async fn untested(
-        &self,
-        req: tracey_proto::UntestedRequest,
-    ) -> Result<tracey_proto::UntestedResponse, vox::VoxError> {
-        self.with_client(|c| async move { c.untested(req).await })
-            .await
-    }
-    pub async fn stale(
-        &self,
-        req: tracey_proto::StaleRequest,
-    ) -> Result<tracey_proto::StaleResponse, vox::VoxError> {
-        self.with_client(|c| async move { c.stale(req).await })
-            .await
-    }
-    pub async fn unmapped(
-        &self,
-        req: tracey_proto::UnmappedRequest,
-    ) -> Result<tracey_proto::UnmappedResponse, vox::VoxError> {
-        self.with_client(|c| async move { c.unmapped(req).await })
-            .await
-    }
-    pub async fn rule(
-        &self,
-        rule_id: tracey_core::RuleId,
-    ) -> Result<Option<tracey_proto::RuleInfo>, vox::VoxError> {
-        self.with_client(|c| async move { c.rule(rule_id).await })
-            .await
-    }
-    pub async fn config(&self) -> Result<tracey_api::ApiConfig, vox::VoxError> {
-        self.with_client(|c| async move { c.config().await }).await
-    }
-    pub async fn vfs_open(&self, path: String, content: String) -> Result<(), vox::VoxError> {
-        self.with_client(|c| async move { c.vfs_open(path, content).await })
-            .await
-    }
-    pub async fn vfs_change(&self, path: String, content: String) -> Result<(), vox::VoxError> {
-        self.with_client(|c| async move { c.vfs_change(path, content).await })
-            .await
-    }
-    pub async fn vfs_close(&self, path: String) -> Result<(), vox::VoxError> {
-        self.with_client(|c| async move { c.vfs_close(path).await })
-            .await
-    }
-    pub async fn reload(&self) -> Result<tracey_proto::ReloadResponse, vox::VoxError> {
-        self.with_client(|c| async move { c.reload().await }).await
-    }
-    pub async fn version(&self) -> Result<u64, vox::VoxError> {
-        self.with_client(|c| async move { c.version().await }).await
-    }
-    pub async fn health(&self) -> Result<tracey_proto::HealthResponse, vox::VoxError> {
-        self.with_client(|c| async move { c.health().await }).await
-    }
-    pub async fn shutdown(&self) -> Result<(), vox::VoxError> {
-        self.with_client(|c| async move { c.shutdown().await })
-            .await
-    }
-    pub async fn subscribe(
-        &self,
-        updates: vox::Tx<tracey_proto::DataUpdate>,
-    ) -> Result<(), vox::VoxError> {
-        self.with_client(|c| async move { c.subscribe(updates).await })
-            .await
-    }
-    pub async fn forward(
-        &self,
-        spec: String,
-        impl_name: String,
-    ) -> Result<Option<tracey_api::ApiSpecForward>, vox::VoxError> {
-        self.with_client(|c| async move { c.forward(spec, impl_name).await })
-            .await
-    }
-    pub async fn reverse(
-        &self,
-        spec: String,
-        impl_name: String,
-    ) -> Result<Option<tracey_api::ApiReverseData>, vox::VoxError> {
-        self.with_client(|c| async move { c.reverse(spec, impl_name).await })
-            .await
-    }
-    pub async fn file(
-        &self,
-        req: tracey_proto::FileRequest,
-    ) -> Result<Option<tracey_api::ApiFileData>, vox::VoxError> {
-        self.with_client(|c| async move { c.file(req).await }).await
-    }
-    pub async fn spec_content(
-        &self,
-        spec: String,
-        impl_name: String,
-    ) -> Result<Option<tracey_api::ApiSpecData>, vox::VoxError> {
-        self.with_client(|c| async move { c.spec_content(spec, impl_name).await })
-            .await
-    }
-    pub async fn search(
-        &self,
-        query: String,
-        limit: u32,
-    ) -> Result<Vec<tracey_proto::SearchResult>, vox::VoxError> {
-        self.with_client(|c| async move { c.search(query, limit).await })
-            .await
-    }
-    pub async fn update_file_range(
-        &self,
-        req: tracey_proto::UpdateFileRangeRequest,
-    ) -> Result<(), vox::VoxError<tracey_proto::UpdateError>> {
-        self.with_client(|c| async move { c.update_file_range(req).await })
-            .await
-    }
-    pub async fn is_test_file(&self, path: String) -> Result<bool, vox::VoxError> {
-        self.with_client(|c| async move { c.is_test_file(path).await })
-            .await
-    }
-    pub async fn lsp_hover(
-        &self,
-        req: tracey_proto::LspPositionRequest,
-    ) -> Result<Option<tracey_proto::HoverInfo>, vox::VoxError> {
-        self.with_client(|c| async move { c.lsp_hover(req).await })
-            .await
-    }
-    pub async fn lsp_definition(
-        &self,
-        req: tracey_proto::LspPositionRequest,
-    ) -> Result<Vec<tracey_proto::LspLocation>, vox::VoxError> {
-        self.with_client(|c| async move { c.lsp_definition(req).await })
-            .await
-    }
-    pub async fn lsp_implementation(
-        &self,
-        req: tracey_proto::LspPositionRequest,
-    ) -> Result<Vec<tracey_proto::LspLocation>, vox::VoxError> {
-        self.with_client(|c| async move { c.lsp_implementation(req).await })
-            .await
-    }
-    pub async fn lsp_references(
-        &self,
-        req: tracey_proto::LspReferencesRequest,
-    ) -> Result<Vec<tracey_proto::LspLocation>, vox::VoxError> {
-        self.with_client(|c| async move { c.lsp_references(req).await })
-            .await
-    }
-    pub async fn lsp_completions(
-        &self,
-        req: tracey_proto::LspPositionRequest,
-    ) -> Result<Vec<tracey_proto::LspCompletionItem>, vox::VoxError> {
-        self.with_client(|c| async move { c.lsp_completions(req).await })
-            .await
-    }
-    pub async fn lsp_workspace_diagnostics(
-        &self,
-    ) -> Result<Vec<tracey_proto::LspFileDiagnostics>, vox::VoxError> {
-        self.with_client(|c| async move { c.lsp_workspace_diagnostics().await })
-            .await
-    }
-    pub async fn lsp_document_symbols(
-        &self,
-        req: tracey_proto::LspDocumentRequest,
-    ) -> Result<Vec<tracey_proto::LspSymbol>, vox::VoxError> {
-        self.with_client(|c| async move { c.lsp_document_symbols(req).await })
-            .await
-    }
-    pub async fn lsp_workspace_symbols(
-        &self,
-        query: String,
-    ) -> Result<Vec<tracey_proto::LspSymbol>, vox::VoxError> {
-        self.with_client(|c| async move { c.lsp_workspace_symbols(query).await })
-            .await
-    }
-    pub async fn lsp_semantic_tokens(
-        &self,
-        req: tracey_proto::LspDocumentRequest,
-    ) -> Result<Vec<tracey_proto::LspSemanticToken>, vox::VoxError> {
-        self.with_client(|c| async move { c.lsp_semantic_tokens(req).await })
-            .await
-    }
-    pub async fn lsp_code_lens(
-        &self,
-        req: tracey_proto::LspDocumentRequest,
-    ) -> Result<Vec<tracey_proto::LspCodeLens>, vox::VoxError> {
-        self.with_client(|c| async move { c.lsp_code_lens(req).await })
-            .await
-    }
-    pub async fn lsp_inlay_hints(
-        &self,
-        req: tracey_proto::InlayHintsRequest,
-    ) -> Result<Vec<tracey_proto::LspInlayHint>, vox::VoxError> {
-        self.with_client(|c| async move { c.lsp_inlay_hints(req).await })
-            .await
-    }
-    pub async fn lsp_prepare_rename(
-        &self,
-        req: tracey_proto::LspPositionRequest,
-    ) -> Result<Option<tracey_proto::PrepareRenameResult>, vox::VoxError> {
-        self.with_client(|c| async move { c.lsp_prepare_rename(req).await })
-            .await
-    }
-    pub async fn lsp_rename(
-        &self,
-        req: tracey_proto::LspRenameRequest,
-    ) -> Result<Vec<tracey_proto::LspTextEdit>, vox::VoxError> {
-        self.with_client(|c| async move { c.lsp_rename(req).await })
-            .await
-    }
-    pub async fn lsp_code_actions(
-        &self,
-        req: tracey_proto::LspPositionRequest,
-    ) -> Result<Vec<tracey_proto::LspCodeAction>, vox::VoxError> {
-        self.with_client(|c| async move { c.lsp_code_actions(req).await })
-            .await
-    }
-    pub async fn lsp_document_highlight(
-        &self,
-        req: tracey_proto::LspPositionRequest,
-    ) -> Result<Vec<tracey_proto::LspLocation>, vox::VoxError> {
-        self.with_client(|c| async move { c.lsp_document_highlight(req).await })
-            .await
-    }
-    pub async fn validate(
-        &self,
-        req: tracey_proto::ValidateRequest,
-    ) -> Result<tracey_api::ValidationResult, vox::VoxError> {
-        self.with_client(|c| async move { c.validate(req).await })
-            .await
-    }
-    pub async fn config_add_exclude(
-        &self,
-        req: tracey_proto::ConfigPatternRequest,
-    ) -> Result<(), vox::VoxError<String>> {
-        self.with_client(|c| async move { c.config_add_exclude(req).await })
-            .await
-    }
-    pub async fn config_add_include(
-        &self,
-        req: tracey_proto::ConfigPatternRequest,
-    ) -> Result<(), vox::VoxError<String>> {
-        self.with_client(|c| async move { c.config_add_include(req).await })
-            .await
     }
 }
 

--- a/crates/tracey/src/daemon/mod.rs
+++ b/crates/tracey/src/daemon/mod.rs
@@ -498,7 +498,8 @@ pub async fn run(project_root: PathBuf, config_path: PathBuf) -> Result<()> {
 
                 tokio::spawn(async move {
                     // Create dispatcher (wraps service with generated dispatch + tracing)
-                    let dispatcher = TraceyDaemonDispatcher::new(service);
+                    let dispatcher = TraceyDaemonDispatcher::new(service)
+                        .with_middleware(vox::ServerLogging::default());
                     let (session_task_tx, session_task_rx) =
                         tokio::sync::oneshot::channel::<tokio::task::JoinHandle<()>>();
 
@@ -512,7 +513,10 @@ pub async fn run(project_root: PathBuf, config_path: PathBuf) -> Result<()> {
                         .establish_or_resume::<tracey_proto::TraceyDaemonClient>(dispatcher)
                         .await
                     {
-                        Ok(vox::SessionAcceptOutcome::Established(client_guard, session_handle)) => {
+                        Ok(vox::SessionAcceptOutcome::Established(
+                            client_guard,
+                            session_handle,
+                        )) => {
                             let has_resume_key = session_handle.resume_key().is_some();
                             info!(attachment_id, has_resume_key, "Daemon session established");
                             let _client_guard = client_guard;

--- a/crates/tracey/src/daemon/mod.rs
+++ b/crates/tracey/src/daemon/mod.rs
@@ -512,10 +512,7 @@ pub async fn run(project_root: PathBuf, config_path: PathBuf) -> Result<()> {
                         .establish_or_resume::<tracey_proto::TraceyDaemonClient>(dispatcher)
                         .await
                     {
-                        Ok(vox::SessionAcceptOutcome::Established(
-                            client_guard,
-                            session_handle,
-                        )) => {
+                        Ok(vox::SessionAcceptOutcome::Established(client_guard, session_handle)) => {
                             let has_resume_key = session_handle.resume_key().is_some();
                             info!(attachment_id, has_resume_key, "Daemon session established");
                             let _client_guard = client_guard;

--- a/crates/tracey/src/daemon/mod.rs
+++ b/crates/tracey/src/daemon/mod.rs
@@ -42,7 +42,7 @@ use vox_stream::LocalLinkAcceptor;
 use service::TraceyDaemonDispatcher;
 use watcher::{WatcherEvent, WatcherManager, WatcherState};
 
-pub use client::{DaemonClient, DaemonConnector, new_client};
+pub use client::{DaemonClient, DaemonConnector, TraceyDaemonClient, new_client};
 pub use engine::Engine;
 pub use service::TraceyService;
 pub use watcher::WatcherState as DaemonWatcherState;
@@ -467,6 +467,8 @@ pub async fn run(project_root: PathBuf, config_path: PathBuf) -> Result<()> {
         Instant::now().elapsed().as_secs(), // Will be updated on each connection
     ));
     let start_time = Instant::now();
+    let session_registry = vox::SessionRegistry::default();
+    let next_attachment_id = Arc::new(AtomicU64::new(1));
 
     // Accept connections and handle vox RPC
     loop {
@@ -487,10 +489,12 @@ pub async fn run(project_root: PathBuf, config_path: PathBuf) -> Result<()> {
             Ok(Ok(stream)) => {
                 // Update last activity
                 last_activity.store(start_time.elapsed().as_secs(), Ordering::Relaxed);
-                info!("New connection accepted");
+                let attachment_id = next_attachment_id.fetch_add(1, Ordering::Relaxed);
+                info!(attachment_id, "Inbound daemon link accepted");
 
                 let service = service.clone();
                 let last_activity = Arc::clone(&last_activity);
+                let session_registry = session_registry.clone();
 
                 tokio::spawn(async move {
                     // Create dispatcher (wraps service with generated dispatch + tracing)
@@ -503,24 +507,48 @@ pub async fn run(project_root: PathBuf, config_path: PathBuf) -> Result<()> {
                             let handle = tokio::spawn(fut);
                             let _ = session_task_tx.send(handle);
                         })
-                        .establish::<tracey_proto::TraceyDaemonClient>(dispatcher)
+                        .session_registry(session_registry)
+                        .resumable()
+                        .establish_or_resume::<tracey_proto::TraceyDaemonClient>(dispatcher)
                         .await
                     {
-                        Ok((client_guard, session_handle)) => {
-                            info!("Connection established");
+                        Ok(vox::SessionAcceptOutcome::Established(
+                            client_guard,
+                            session_handle,
+                        )) => {
+                            let has_resume_key = session_handle.resume_key().is_some();
+                            info!(attachment_id, has_resume_key, "Daemon session established");
                             let _client_guard = client_guard;
                             let _session_handle = session_handle;
-                            if let Ok(session_task) = session_task_rx.await {
-                                let _ = session_task.await;
+                            match session_task_rx.await {
+                                Ok(session_task) => {
+                                    if let Err(error) = session_task.await {
+                                        warn!(
+                                            attachment_id,
+                                            error = %error,
+                                            "Daemon session task ended with join error"
+                                        );
+                                    }
+                                }
+                                Err(_) => {
+                                    warn!(
+                                        attachment_id,
+                                        "Daemon session task channel closed before spawn"
+                                    );
+                                }
                             }
+                            info!(attachment_id, "Daemon session ended");
+                        }
+                        Ok(vox::SessionAcceptOutcome::Resumed) => {
+                            info!(attachment_id, "Daemon session resumed on replacement link");
                         }
                         Err(e) => {
-                            error!("Connection setup failed: {}", e);
+                            error!(attachment_id, error = %e, "Connection setup failed");
                         }
                     }
 
                     last_activity.store(start_time.elapsed().as_secs(), Ordering::Relaxed);
-                    info!("Connection closed");
+                    info!(attachment_id, "Link attachment closed");
                 });
             }
             Ok(Err(e)) => {

--- a/crates/tracey/src/daemon/mod.rs
+++ b/crates/tracey/src/daemon/mod.rs
@@ -32,12 +32,12 @@ pub mod service;
 pub mod watcher;
 
 use eyre::{Result, WrapErr};
-use roam_stream::LocalLinkAcceptor;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tracing::{debug, error, info, warn};
+use vox_stream::LocalLinkAcceptor;
 
 use service::TraceyDaemonDispatcher;
 use watcher::{WatcherEvent, WatcherManager, WatcherState};
@@ -227,12 +227,12 @@ pub async fn run(project_root: PathBuf, config_path: PathBuf) -> Result<()> {
 
     // r[impl daemon.lifecycle.stale-socket]
     // Remove stale endpoint if it exists; if it's alive, fail fast instead.
-    if roam_local::endpoint_exists(&endpoint) {
-        if roam_local::connect(&endpoint).await.is_ok() {
+    if vox_local::endpoint_exists(&endpoint) {
+        if vox_local::connect(&endpoint).await.is_ok() {
             eyre::bail!("Daemon already running at {}", endpoint);
         } else {
             info!("Removing stale socket at {}", endpoint);
-            let _ = roam_local::remove_endpoint(&endpoint);
+            let _ = vox_local::remove_endpoint(&endpoint);
         }
     }
 
@@ -468,14 +468,14 @@ pub async fn run(project_root: PathBuf, config_path: PathBuf) -> Result<()> {
     ));
     let start_time = Instant::now();
 
-    // Accept connections and handle roam RPC
+    // Accept connections and handle vox RPC
     loop {
         // Check for shutdown signal or accept with timeout
         let accept_result = tokio::select! {
             _ = shutdown_rx.changed() => {
                 if *shutdown_rx.borrow() {
                     info!("Shutdown signal received");
-                    let _ = roam_local::remove_endpoint(&endpoint);
+                    let _ = vox_local::remove_endpoint(&endpoint);
                     return Ok(());
                 }
                 continue;
@@ -498,7 +498,7 @@ pub async fn run(project_root: PathBuf, config_path: PathBuf) -> Result<()> {
                     let (session_task_tx, session_task_rx) =
                         tokio::sync::oneshot::channel::<tokio::task::JoinHandle<()>>();
 
-                    match roam::acceptor(stream)
+                    match vox::acceptor_on(stream)
                         .spawn_fn(move |fut| {
                             let handle = tokio::spawn(fut);
                             let _ = session_task_tx.send(handle);
@@ -535,7 +535,7 @@ pub async fn run(project_root: PathBuf, config_path: PathBuf) -> Result<()> {
                 if idle_secs >= DEFAULT_IDLE_TIMEOUT_SECS {
                     info!("No connections for {} seconds, shutting down", idle_secs);
                     // Clean up endpoint
-                    let _ = roam_local::remove_endpoint(&endpoint);
+                    let _ = vox_local::remove_endpoint(&endpoint);
                     return Ok(());
                 }
             }
@@ -714,12 +714,12 @@ async fn run_smart_watcher(
 #[allow(dead_code)]
 pub async fn is_running(project_root: &Path) -> bool {
     let endpoint = local_endpoint(project_root);
-    if !roam_local::endpoint_exists(&endpoint) {
+    if !vox_local::endpoint_exists(&endpoint) {
         return false;
     }
 
     // Try to connect
-    match roam_local::connect(&endpoint).await {
+    match vox_local::connect(&endpoint).await {
         Ok(_) => true,
         Err(_) => {
             // Endpoint exists but can't connect - stale
@@ -731,9 +731,9 @@ pub async fn is_running(project_root: &Path) -> bool {
 /// Connect to a running daemon, or return an error.
 #[allow(dead_code)]
 #[cfg(unix)]
-pub async fn connect(project_root: &Path) -> Result<roam_local::LocalStream> {
+pub async fn connect(project_root: &Path) -> Result<vox_local::LocalStream> {
     let endpoint = local_endpoint(project_root);
-    roam_local::connect(&endpoint)
+    vox_local::connect(&endpoint)
         .await
         .wrap_err_with(|| format!("Failed to connect to daemon at {}", endpoint))
 }
@@ -741,9 +741,9 @@ pub async fn connect(project_root: &Path) -> Result<roam_local::LocalStream> {
 /// Connect to a running daemon, or return an error.
 #[allow(dead_code)]
 #[cfg(windows)]
-pub async fn connect(project_root: &Path) -> Result<roam_local::LocalStream> {
+pub async fn connect(project_root: &Path) -> Result<vox_local::LocalStream> {
     let endpoint = local_endpoint(project_root);
-    roam_local::connect(&endpoint)
+    vox_local::connect(&endpoint)
         .await
         .wrap_err_with(|| format!("Failed to connect to daemon at {}", endpoint))
 }

--- a/crates/tracey/src/daemon/service.rs
+++ b/crates/tracey/src/daemon/service.rs
@@ -1,6 +1,6 @@
 //! TraceyDaemon service implementation.
 //!
-//! Implements the roam RPC service by delegating to the Engine.
+//! Implements the vox RPC service by delegating to the Engine.
 
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -12,7 +12,7 @@ use super::engine::Engine;
 use super::watcher::WatcherState;
 use crate::rule_suggestions::suggest_similar_rule_ids;
 use crate::server::QueryEngine;
-use roam::Tx;
+use vox::Tx;
 
 // Re-export the generated dispatcher from tracey-proto
 pub use tracey_proto::TraceyDaemonDispatcher;

--- a/crates/tracey/src/daemon/service.rs
+++ b/crates/tracey/src/daemon/service.rs
@@ -227,6 +227,7 @@ impl TraceyDaemon for TraceyService {
         let stats = query.status();
 
         StatusResponse {
+            api_schema_version: 1,
             impls: stats
                 .into_iter()
                 .map(|(spec, impl_name, s)| ImplStatus {

--- a/crates/tracey/src/main.rs
+++ b/crates/tracey/src/main.rs
@@ -477,7 +477,7 @@ async fn main() -> Result<()> {
         Command::Query { root, json, query } => {
             let project_root = root.unwrap_or_else(|| find_project_root().unwrap_or_default());
             let query_client =
-                bridge::query::QueryClient::new(project_root, bridge::query::Caller::Cli);
+                bridge::query::QueryClient::new(project_root, bridge::query::Caller::Cli).await?;
             init_tracing(TracingConfig {
                 log_file: None,
                 enable_console: !json,

--- a/crates/tracey/src/main.rs
+++ b/crates/tracey/src/main.rs
@@ -1023,7 +1023,7 @@ async fn show_status(root: Option<PathBuf>, json: bool) -> Result<()> {
     let endpoint = daemon::local_endpoint(&project_root);
 
     // Try to connect without auto-starting
-    let stream = match roam_stream::LocalLink::connect(&endpoint).await {
+    let stream = match vox_stream::LocalLink::connect(&endpoint).await {
         Ok(s) => s,
         Err(_) => {
             if json {
@@ -1035,7 +1035,7 @@ async fn show_status(root: Option<PathBuf>, json: bool) -> Result<()> {
         }
     };
 
-    let (client, _session_handle) = roam::initiator(stream)
+    let (client, _session_handle) = vox::initiator_on(stream, vox::TransportMode::Bare)
         .establish::<tracey_proto::TraceyDaemonClient>(())
         .await
         .map_err(|e| eyre::eyre!("failed to connect to daemon: {e:?}"))?;
@@ -1410,15 +1410,15 @@ async fn kill_daemon(root: Option<PathBuf>) -> Result<()> {
     let endpoint = daemon::local_endpoint(&project_root);
 
     // Check if endpoint exists
-    if !roam_local::endpoint_exists(&endpoint) {
+    if !vox_local::endpoint_exists(&endpoint) {
         println!("{}: No daemon running", "Info".cyan());
         return Ok(());
     }
 
     // Try to connect and send shutdown
-    match roam_stream::LocalLink::connect(&endpoint).await {
+    match vox_stream::LocalLink::connect(&endpoint).await {
         Ok(stream) => {
-            let (client, _session_handle) = roam::initiator(stream)
+            let (client, _session_handle) = vox::initiator_on(stream, vox::TransportMode::Bare)
                 .establish::<tracey_proto::TraceyDaemonClient>(())
                 .await
                 .map_err(|e| eyre::eyre!("failed to connect to daemon: {e:?}"))?;
@@ -1448,7 +1448,7 @@ async fn kill_daemon(root: Option<PathBuf>) -> Result<()> {
                 "{}: Daemon not responding, cleaning up stale socket",
                 "Info".cyan()
             );
-            let _ = roam_local::remove_endpoint(&endpoint);
+            let _ = vox_local::remove_endpoint(&endpoint);
             println!("{}: Cleaned up", "Success".green());
         }
     }

--- a/crates/tracey/src/main.rs
+++ b/crates/tracey/src/main.rs
@@ -10,6 +10,7 @@ use owo_colors::OwoColorize;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command as ProcessCommand, Stdio};
+use std::sync::Arc;
 
 // Use the library crate
 use tracey::{bridge, daemon, find_project_root};
@@ -417,7 +418,7 @@ async fn main() -> Result<()> {
                 log_file: Some(log_path),
                 enable_console: true,
                 console_ansi: true,
-                default_filter: "tracey=info",
+                default_filter: "tracey=info,vox=trace,vox_core=trace",
             })?;
 
             daemon::run(project_root, config_path).await
@@ -794,7 +795,10 @@ async fn query_json(qc: &bridge::query::QueryClient, query: QueryCommand) -> (St
 
 #[cfg(test)]
 mod tests {
-    use super::ValidationDeny;
+    use super::{
+        DEFAULT_LOG_ROTATION_BACKUPS, RotatingLogWriter, ValidationDeny, rotated_log_path,
+    };
+    use std::io::Write as _;
 
     #[test]
     fn parse_validation_deny_accepts_warnings_variants() {
@@ -824,6 +828,33 @@ mod tests {
     fn validation_deny_warnings_fails_on_warnings() {
         let deny = ValidationDeny::parse(&["warnings".to_string()]).expect("parse warnings");
         assert!(deny.should_fail(0, 1));
+    }
+
+    #[test]
+    fn rotating_log_writer_rotates_and_keeps_recent_backups() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("daemon.log");
+
+        std::fs::write(&path, b"older log").expect("seed current log");
+        std::fs::write(rotated_log_path(&path, 1), b"oldest backup").expect("seed backup");
+
+        let mut writer =
+            RotatingLogWriter::new(path.clone(), 8, DEFAULT_LOG_ROTATION_BACKUPS).expect("writer");
+        writer.write_all(b"new log").expect("write");
+        writer.flush().expect("flush");
+
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("current log"),
+            "new log"
+        );
+        assert_eq!(
+            std::fs::read_to_string(rotated_log_path(&path, 1)).expect("first backup"),
+            "older log"
+        );
+        assert_eq!(
+            std::fs::read_to_string(rotated_log_path(&path, 2)).expect("second backup"),
+            "oldest backup"
+        );
     }
 }
 
@@ -861,6 +892,153 @@ struct TracingConfig {
     default_filter: &'static str,
 }
 
+const DEFAULT_LOG_ROTATION_MAX_BYTES: u64 = 64 * 1024 * 1024;
+const DEFAULT_LOG_ROTATION_BACKUPS: usize = 4;
+
+#[derive(Clone)]
+struct RotatingLogWriter {
+    state: Arc<std::sync::Mutex<RotatingLogState>>,
+}
+
+struct RotatingLogState {
+    path: PathBuf,
+    file: std::fs::File,
+    size: u64,
+    max_bytes: u64,
+    max_backups: usize,
+}
+
+impl RotatingLogWriter {
+    fn new(path: PathBuf, max_bytes: u64, max_backups: usize) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        rotate_log_file_if_needed(&path, max_bytes, max_backups)?;
+        let (file, size) = open_log_file_for_append(&path)?;
+        Ok(Self {
+            state: Arc::new(std::sync::Mutex::new(RotatingLogState {
+                path,
+                file,
+                size,
+                max_bytes,
+                max_backups,
+            })),
+        })
+    }
+}
+
+impl std::io::Write for RotatingLogWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.write_all(buf)?;
+        Ok(buf.len())
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| std::io::Error::other("rotating log writer poisoned"))?;
+        write_with_rotation(&mut state, buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| std::io::Error::other("rotating log writer poisoned"))?;
+        state.file.flush()
+    }
+}
+
+fn open_log_file_for_append(path: &Path) -> std::io::Result<(std::fs::File, u64)> {
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    let size = file.metadata()?.len();
+    Ok((file, size))
+}
+
+fn rotated_log_path(path: &Path, index: usize) -> PathBuf {
+    let mut os = path.as_os_str().to_os_string();
+    os.push(format!(".{index}"));
+    PathBuf::from(os)
+}
+
+fn rotate_log_files(path: &Path, max_backups: usize) -> std::io::Result<()> {
+    if max_backups == 0 {
+        if let Err(error) = std::fs::remove_file(path)
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            return Err(error);
+        }
+        return Ok(());
+    }
+
+    let oldest = rotated_log_path(path, max_backups);
+    if let Err(error) = std::fs::remove_file(&oldest)
+        && error.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(error);
+    }
+
+    for index in (1..max_backups).rev() {
+        let src = rotated_log_path(path, index);
+        let dst = rotated_log_path(path, index + 1);
+        if let Err(error) = std::fs::rename(&src, &dst)
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            return Err(error);
+        }
+    }
+
+    if let Err(error) = std::fs::rename(path, rotated_log_path(path, 1))
+        && error.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(error);
+    }
+
+    Ok(())
+}
+
+fn rotate_log_file_if_needed(
+    path: &Path,
+    max_bytes: u64,
+    max_backups: usize,
+) -> std::io::Result<()> {
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.len() >= max_bytes => rotate_log_files(path, max_backups),
+        Ok(_) | Err(_) => Ok(()),
+    }
+}
+
+fn write_with_rotation(state: &mut RotatingLogState, buf: &[u8]) -> std::io::Result<()> {
+    if state.size > 0 && state.size.saturating_add(buf.len() as u64) > state.max_bytes {
+        state.file.flush()?;
+        rotate_log_files(&state.path, state.max_backups)?;
+        let (file, size) = open_log_file_for_append(&state.path)?;
+        state.file = file;
+        state.size = size;
+    }
+
+    state.file.write_all(buf)?;
+    state.size = state.size.saturating_add(buf.len() as u64);
+    Ok(())
+}
+
+fn append_to_rotating_log_file(path: &Path, bytes: &[u8]) -> Result<()> {
+    let writer = RotatingLogWriter::new(
+        path.to_path_buf(),
+        DEFAULT_LOG_ROTATION_MAX_BYTES,
+        DEFAULT_LOG_ROTATION_BACKUPS,
+    )?;
+    let mut writer = writer;
+    writer.write_all(bytes)?;
+    writer.flush()?;
+    Ok(())
+}
+
 /// Initialize tracing with optional file logging.
 fn init_tracing(config: TracingConfig) -> Result<()> {
     use tracing_subscriber::layer::SubscriberExt;
@@ -879,20 +1057,17 @@ fn init_tracing(config: TracingConfig) -> Result<()> {
     });
 
     let file_layer = if let Some(log_path) = config.log_file {
-        // Ensure parent directory exists
-        if let Some(parent) = log_path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        let log_file = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&log_path)?;
+        let log_file = RotatingLogWriter::new(
+            log_path,
+            DEFAULT_LOG_ROTATION_MAX_BYTES,
+            DEFAULT_LOG_ROTATION_BACKUPS,
+        )?;
+        let make_writer = move || log_file.clone();
 
         Some(
             tracing_subscriber::fmt::layer()
                 .with_ansi(false)
-                .with_writer(log_file),
+                .with_writer(make_writer),
         )
     } else {
         None
@@ -919,23 +1094,13 @@ fn write_bridge_start_marker(
     project_root: &std::path::Path,
     config_path: &std::path::Path,
 ) -> Result<()> {
-    use std::io::Write;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    if let Some(parent) = log_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-
-    let mut log_file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(log_path)?;
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    writeln!(
-        log_file,
+    let line = format!(
         "[ts={} pid={}] starting {} root={} config={} cwd={}",
         now,
         std::process::id(),
@@ -943,7 +1108,9 @@ fn write_bridge_start_marker(
         project_root.display(),
         config_path.display(),
         std::env::current_dir()?.display()
-    )?;
+    );
+    append_to_rotating_log_file(log_path, line.as_bytes())?;
+    append_to_rotating_log_file(log_path, b"\n")?;
 
     Ok(())
 }
@@ -1477,10 +1644,7 @@ async fn kill_daemon(root: Option<PathBuf>) -> Result<()> {
             let _ = vox_local::remove_endpoint(&endpoint);
             println!("{}: Cleaned up", "Success".green());
         } else if shutdown_sent {
-            println!(
-                "{}: Daemon still appears to be running",
-                "Warning".yellow()
-            );
+            println!("{}: Daemon still appears to be running", "Warning".yellow());
         }
     }
 

--- a/crates/tracey/src/main.rs
+++ b/crates/tracey/src/main.rs
@@ -1416,6 +1416,7 @@ async fn kill_daemon(root: Option<PathBuf>) -> Result<()> {
     }
 
     // Try to connect and send shutdown
+    let mut shutdown_sent = false;
     match vox_stream::LocalLink::connect(&endpoint).await {
         Ok(stream) => {
             let (client, _session_handle) = vox::initiator_on(stream, vox::TransportMode::Bare)
@@ -1425,12 +1426,14 @@ async fn kill_daemon(root: Option<PathBuf>) -> Result<()> {
 
             match client.shutdown().await {
                 Ok(()) => {
+                    shutdown_sent = true;
                     println!("{}: Shutdown signal sent", "Success".green());
                 }
                 Err(e) => {
                     // Connection may close before we get a response, that's OK
                     let err_str = format!("{e:?}");
-                    if err_str.contains("closed") {
+                    if err_str.to_ascii_lowercase().contains("closed") {
+                        shutdown_sent = true;
                         println!("{}: Daemon stopped", "Success".green());
                     } else {
                         println!(
@@ -1450,6 +1453,34 @@ async fn kill_daemon(root: Option<PathBuf>) -> Result<()> {
             );
             let _ = vox_local::remove_endpoint(&endpoint);
             println!("{}: Cleaned up", "Success".green());
+            return Ok(());
+        }
+    }
+
+    // If shutdown was sent (or likely accepted), give daemon a moment to remove its endpoint.
+    if shutdown_sent {
+        for _ in 0..20 {
+            if !vox_local::endpoint_exists(&endpoint) {
+                return Ok(());
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+
+    // Endpoint still exists. If it's not connectable anymore, clean up stale socket.
+    if vox_local::endpoint_exists(&endpoint) {
+        if vox_stream::LocalLink::connect(&endpoint).await.is_err() {
+            println!(
+                "{}: Daemon not responding, cleaning up stale socket",
+                "Info".cyan()
+            );
+            let _ = vox_local::remove_endpoint(&endpoint);
+            println!("{}: Cleaned up", "Success".green());
+        } else if shutdown_sent {
+            println!(
+                "{}: Daemon still appears to be running",
+                "Warning".yellow()
+            );
         }
     }
 

--- a/crates/tracey/tests/common/mod.rs
+++ b/crates/tracey/tests/common/mod.rs
@@ -5,10 +5,10 @@
 use std::path::PathBuf;
 use std::sync::Once;
 
-use roam_core::memory_link_pair as memory_transport_pair;
 use tracey_proto::{TraceyDaemonClient, TraceyDaemonDispatcher};
 use tracing::debug;
 use tracing_subscriber::EnvFilter;
+use vox_core::memory_link_pair as memory_transport_pair;
 
 static TEST_TRACING: Once = Once::new();
 
@@ -41,10 +41,11 @@ pub async fn create_test_rpc_service(service: tracey::daemon::TraceyService) -> 
     let (client_transport, server_transport) = memory_transport_pair(256);
     let dispatcher = TraceyDaemonDispatcher::new(service);
 
-    let server_fut = roam::acceptor(server_transport).establish::<TraceyDaemonClient>(dispatcher);
-    let client_fut = roam::initiator(client_transport).establish::<TraceyDaemonClient>(());
+    let server_fut = vox::acceptor_on(server_transport).establish::<TraceyDaemonClient>(dispatcher);
+    let client_fut = vox::initiator_on(client_transport, vox::TransportMode::Bare)
+        .establish::<TraceyDaemonClient>(());
     let (server_result, client_result) = tokio::try_join!(server_fut, client_fut)
-        .expect("failed to establish in-memory roam transport");
+        .expect("failed to establish in-memory vox transport");
     let (server_client, _server_session_handle) = server_result;
     let (client, _client_session_handle) = client_result;
     debug!("create_test_rpc_service: server+client established");

--- a/crates/tracey/tests/integration_tests.rs
+++ b/crates/tracey/tests/integration_tests.rs
@@ -12,7 +12,7 @@ use tracey_proto::*;
 // Re-export test modules
 mod common;
 
-fn rpc<T, E: std::fmt::Debug>(res: Result<T, roam::RoamError<E>>) -> T {
+fn rpc<T, E: std::fmt::Debug>(res: Result<T, vox::VoxError<E>>) -> T {
     res.expect("RPC call failed")
 }
 

--- a/crates/tracey/tests/lsp_diagnostic_lifecycle_tests.rs
+++ b/crates/tracey/tests/lsp_diagnostic_lifecycle_tests.rs
@@ -16,7 +16,7 @@ use tracey_proto::*;
 
 mod common;
 
-fn rpc<T, E: std::fmt::Debug>(res: Result<T, roam::RoamError<E>>) -> T {
+fn rpc<T, E: std::fmt::Debug>(res: Result<T, vox::VoxError<E>>) -> T {
     res.expect("RPC call failed")
 }
 

--- a/crates/tracey/tests/mcp_tests.rs
+++ b/crates/tracey/tests/mcp_tests.rs
@@ -11,7 +11,7 @@ use tracey_proto::*;
 
 mod common;
 
-fn rpc<T, E: std::fmt::Debug>(res: Result<T, roam::RoamError<E>>) -> T {
+fn rpc<T, E: std::fmt::Debug>(res: Result<T, vox::VoxError<E>>) -> T {
     res.expect("RPC call failed")
 }
 

--- a/crates/tracey/tests/watcher_tests.rs
+++ b/crates/tracey/tests/watcher_tests.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 
 use tracey::daemon::watcher::{WatcherState, glob_to_watch_dir};
 
-fn rpc<T, E: std::fmt::Debug>(res: Result<T, roam::RoamError<E>>) -> T {
+fn rpc<T, E: std::fmt::Debug>(res: Result<T, vox::VoxError<E>>) -> T {
     res.expect("RPC call failed")
 }
 

--- a/crates/xtask/ent.plist
+++ b/crates/xtask/ent.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.security.get-task-allow</key>
+        <true/>
+    </dict>
+</plist>

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -50,13 +50,21 @@ fn install() {
     std::fs::copy(src, &dst).expect("Failed to copy binary");
     println!("Copied tracey to {}", dst);
 
-    // On macOS, codesign the installed binary to avoid AMFI issues
-    // (signing must happen AFTER copy, not before)
+    // On macOS, codesign the installed binary with get-task-allow entitlement
+    // so that debuggers/profilers can attach (signing must happen AFTER copy)
     #[cfg(target_os = "macos")]
     {
         println!("Signing installed binary...");
+        let ent = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("ent.plist");
         let status = Command::new("codesign")
-            .args(["--sign", "-", "--force", &dst])
+            .args([
+                "--sign",
+                "-",
+                "--force",
+                "--entitlements",
+                ent.to_str().unwrap(),
+                &dst,
+            ])
             .status()
             .expect("Failed to run codesign");
 


### PR DESCRIPTION
## Summary
- Renames all `roam` crate dependencies to their `vox` equivalents (roam→vox, roam-core→vox-core, roam-stream→vox-stream, roam-local→vox-local) at version 0.2.0
- Updates all Rust source references: `roam::service` → `vox::service`, `roam::RoamError` → `vox::VoxError`, `roam::acceptor`/`initiator` → `vox::acceptor_on`/`initiator_on`, and all transport/local IPC types
- Updates README links from roam to vox

## Test plan
- [x] All 273 tests pass
- [x] `cargo check` compiles cleanly
- [x] `cxi` (full release build + install) succeeds