### PR TITLE
Fix relative path in vite config

### DIFF
--- a/crates/tracey/src/bridge/http/dashboard/vite.config.ts
+++ b/crates/tracey/src/bridge/http/dashboard/vite.config.ts
@@ -1,12 +1,21 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
 import preact from "@preact/preset-vite";
 
+const dashboardRoot = fs.realpathSync.native(
+  path.dirname(fileURLToPath(import.meta.url)),
+);
+
 export default defineConfig({
+  root: dashboardRoot,
   plugins: [preact()],
   build: {
     outDir: "dist",
     emptyOutDir: true,
     rollupOptions: {
+      input: path.join(dashboardRoot, "index.html"),
       output: {
         entryFileNames: "assets/index.js",
         assetFileNames: "assets/[name][extname]",


### PR DESCRIPTION
This was causing issues when trying to install tracey with cargo install on windows due to relative paths.

<img width="1482" height="158" alt="image" src="https://github.com/user-attachments/assets/c2dcd0f3-6615-444c-95a1-410639caa783" />

I'm no Vite wizard, so I asked AI for the fix. I cannot guarantee that this is the best way to fix it, but it does work