### PR TITLE
Implement asciidoc support using the `asciidork` parser crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +931,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "asciidork-ast"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b24d00cb1ededc86a6ad851f1b054c8e13d55449adb95a600add47b38e1ddd2"
+dependencies = [
+ "asciidork-core",
+ "bumpalo",
+ "smallvec 1.15.1",
+]
+
+[[package]]
+name = "asciidork-backend"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9ed6afec2dcaeb8ef18a2b9a149cab5a8b148dfff991d7902eb8a791be15a8f"
+dependencies = [
+ "asciidork-ast",
+ "asciidork-core",
+ "dateparser",
+ "lazy_static",
+ "regex",
+ "roman_numerals_fn",
+]
+
+[[package]]
+name = "asciidork-core"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d8cb05558a80b27872c0ba8eb4fd22fc1b7eb81081bfcb791411dfeff7fb55d"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
+name = "asciidork-dr-html-backend"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "858f07290762da36c441df96210ce7b8d1ed245e80a9c5516f80643e67a30538"
+dependencies = [
+ "asciidork-ast",
+ "asciidork-backend",
+ "asciidork-core",
+ "asciidork-eval",
+ "lazy_static",
+ "regex",
+ "roman_numerals_fn",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "asciidork-eval"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bd5cf4daf12b5b0699adcc3a8dbcaf9d8872bf33b26111fdfb0c931783fe46"
+dependencies = [
+ "asciidork-ast",
+ "asciidork-backend",
+]
+
+[[package]]
+name = "asciidork-parser"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c57cdc5e9bdbd61feaba18c7672809911b3dafececc85b46e373d194ec7fe41"
+dependencies = [
+ "asciidork-ast",
+ "asciidork-core",
+ "bumpalo",
+ "jiff",
+ "lazy_static",
+ "regex",
+ "smallvec 1.15.1",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +1249,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "color-backtrace"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1292,12 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "countme"
@@ -1305,6 +1410,18 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "dateparser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ef451feee09ae5ecd8a02e738bd9adee9266b8fa9b44e22d3ce968d8694238"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "lazy_static",
+ "regex",
+]
 
 [[package]]
 name = "deranged"
@@ -2228,6 +2345,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2480,6 +2621,35 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c04ef77ae73f3cf50510712722f0c4e8b46f5aaa1bf5ffad2ae213e6495e78e5"
+dependencies = [
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jobserver"
@@ -3111,6 +3281,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3270,6 +3455,12 @@ dependencies = [
  "num-traits",
  "rand 0.8.5",
 ]
+
+[[package]]
+name = "range_check"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69b9d3e775b8f88eb220da1a4d8baae200d3ec499b8ef14b881362a5f8ad883"
 
 [[package]]
 name = "rayon"
@@ -3457,6 +3648,15 @@ dependencies = [
  "smallvec 1.15.1",
  "structstruck",
  "tokio",
+]
+
+[[package]]
+name = "roman_numerals_fn"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4058a8f9566d31d828427ab40d510eadb8564619d0eea3ad4968c24e93e96a4b"
+dependencies = [
+ "range_check",
 ]
 
 [[package]]
@@ -4501,6 +4701,12 @@ dependencies = [
  "arborium-swift",
  "arborium-typescript",
  "arborium-vb",
+ "asciidork-ast",
+ "asciidork-backend",
+ "asciidork-core",
+ "asciidork-dr-html-backend",
+ "asciidork-parser",
+ "bumpalo",
  "eyre",
  "facet",
  "globset",
@@ -4508,6 +4714,7 @@ dependencies = [
  "marq",
  "pulldown-cmark",
  "rayon",
+ "tokio",
 ]
 
 [[package]]
@@ -4928,10 +5135,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,14 @@ tantivy = "0.22"
 marq = { version = "2.2.0", features = ["all-handlers", "lang-vixen"] }
 pulldown-cmark = "0.13"
 
+# AsciiDoc processing
+asciidork-core = "0.37"
+asciidork-parser = "0.38"
+asciidork-ast = "0.38"
+asciidork-backend = "0.38"
+asciidork-dr-html-backend = "0.38"
+bumpalo = "3"
+
 # CLI/runtime dependencies
 indoc = "2"
 urlencoding = "2.1"

--- a/asciidoc-plan.md
+++ b/asciidoc-plan.md
@@ -1,0 +1,437 @@
+# Plan: Add AsciiDoc support to Tracey
+
+Add `.adoc` (AsciiDoc) as a second supported **spec-file** format alongside
+Markdown. Code-file parsing (`prefix[verb req.id]` references inside source
+code comments) is orthogonal and does not change.
+
+**Key context**: PR #185 (Typst support; open, not yet merged) has already
+designed and landed — in its branch — the exact multi-format abstraction this
+change needs. This plan is deliberately structured to **sit on top of PR #185's
+abstraction** so the two features are symmetric and trivially rebaseable
+against each other. The AsciiDoc implementer should:
+
+1. Rebase on top of `main`.
+2. If PR #185 is already merged, just use the `tracey_core::spec` API.
+3. If PR #185 is **not** yet merged, replicate the same API surface verbatim
+   (not a similar one — identical names, identical signatures). That way the
+   maintainer can merge either PR first and the other rebases cleanly, and
+   the author of PR #185 does not have to re-review a parallel abstraction.
+
+Every name and helper below is quoted from PR #185 by design. Stick to them.
+
+---
+
+## 1. The PR #185 abstraction — what we depend on
+
+PR #185 introduces `crates/tracey-core/src/spec/mod.rs` with this public API
+(reproduce exactly if #185 is not yet merged):
+
+```rust
+// Format classification
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SpecFormat { Markdown, Typst /* + AsciiDoc (this PR) */ }
+
+impl SpecFormat {
+    pub fn from_path(p: &Path) -> Option<Self>;
+    pub fn from_ext(ext: &OsStr) -> Option<Self>;
+}
+
+pub const SPEC_EXTENSIONS: &[&str] = &["md", "markdown", "typ"
+                                       /* + "adoc", "asciidoc", "asc" */];
+pub fn is_spec_extension(ext: &OsStr) -> bool;
+
+// Shared document shape — marq::Document's fields are public, so every
+// backend constructs one directly.
+pub type SpecDoc = marq::Document;
+pub use marq::{DocElement, InlineCodeSpan, ReqDefinition,
+               RuleId as SpecRuleId, SourceSpan};
+
+// Format-dispatched operations (free functions, not a trait — PR #185's
+// stated rationale is that there are only a handful of call sites, every
+// one has a Path, and async-trait boxing is avoided).
+pub async fn parse_spec(fmt: SpecFormat, content: &str) -> eyre::Result<SpecDoc>;
+pub fn diff_inline(fmt: SpecFormat, old: &str, new: &str) -> Option<String>;
+pub fn parse_weight(fmt: SpecFormat, content: &str) -> i32;
+pub fn extract_marker_prefix(fmt: SpecFormat, content: &str, span: SourceSpan)
+    -> Option<String>;
+pub fn id_range_in_marker(fmt: SpecFormat, marker_str: &str)
+    -> eyre::Result<Range<usize>>;
+pub fn rewrite_marker(marker_str: &str, id_range: Range<usize>,
+                      base: &str, new_ver: u32) -> eyre::Result<String>;
+
+// Anchor contract (both formats MUST emit this shape in ReqDefinition::anchor_id)
+pub const REQ_ANCHOR_PREFIX: &str = "r--";
+pub fn req_anchor_id(id: &str) -> String;
+pub fn req_anchor_to_id(anchor: &str) -> Option<&str>;
+
+// Cross-file heading-slug allocator — threaded through the whole render so
+// heading anchors from different files / different formats never collide.
+pub struct SlugAllocator { /* … */ }
+impl SlugAllocator {
+    pub fn alloc(&mut self, base: &str) -> String;
+}
+```
+
+Per-format submodules (`spec/markdown.rs`, `spec/typst.rs`) implement the
+private dispatch targets: `parse`, `diff_inline`, `parse_weight`,
+`extract_marker_prefix`, `id_range_in_marker`. Heavy backends gate their
+compiler behind a Cargo feature (`typst-spec` in PR #185).
+
+PR #185 also extracts `rule_coverage_badge_html(rule, coverage, source_file,
+spec_name, impl_name) -> (String, String)` in `crates/tracey/src/data.rs` so
+non-marq backends can render coverage-aware requirement containers without
+duplicating 70 lines of badge HTML.
+
+`ExtractedRule` in `crates/tracey/src/lib.rs` grows a `pub format: SpecFormat`
+field. `search::RuleEntry` and `search::SearchResult` gain format too, and
+the search index stores "markdown" / "typst" strings.
+
+---
+
+## 2. What this plan adds
+
+Introduce `SpecFormat::AsciiDoc` as a third variant and implement
+`spec/asciidoc.rs`, the analogue of `spec/typst.rs`. Because PR #185 declared
+`SpecFormat` as `#[non_exhaustive]` and left a fallthrough arm in
+`load_spec_content`, the integration seam is narrow and clearly signposted.
+
+### 2.1 Syntax for requirements in AsciiDoc
+
+Mirror Markdown as closely as AsciiDoc's grammar allows. Two variants:
+
+- **Paragraph form** — marker at column 0 as a standalone paragraph:
+
+  ```adoc
+  r[auth.token.validation]
+  The system must validate tokens before granting access.
+  ```
+
+- **Quoted-block form** — AsciiDoc's `____` delimiter (or `[quote]` style
+  block) for multi-paragraph bodies:
+
+  ```adoc
+  [quote]
+  ____
+  r[api.error.format]
+  API errors must follow this format:
+
+  [source,json]
+  ----
+  {"error": "message", "code": 400}
+  ----
+  ____
+  ```
+
+- **Inline markers are text, not definitions** — same rule as Markdown.
+
+- **Heading ids** come from AsciiDoc auto-id, or an explicit `[[id]]` /
+  `[#id]` anchor, then pass through `SlugAllocator::alloc` so they stay
+  globally unique across the spec.
+
+- **Frontmatter / weight** — AsciiDoc convention is a document attribute at
+  the top, e.g. `:weight: 10`. `parse_weight` reads this. A `+++`/`---`
+  TOML/YAML front matter should also be accepted (people mix).
+
+- **Masks for marker extraction** — listing blocks (`----`, `....`), literal
+  blocks, passthrough blocks (`++++`), and line/block comments (`//`,
+  `////`) must all mask markers so example snippets aren't picked up.
+
+- **`include::` directives** — v1: do not follow. Emit a `ParseWarning`.
+  Tracking transitive includes is what PR #185 does for Typst (out-param
+  `deps: &mut HashSet<PathBuf>`); AsciiDoc can adopt the same hook in a
+  follow-up if users ask for it, without changing the public API shape.
+
+Add a new section to `docs/content/spec/tracey.md` with rules
+`r[asciidoc.syntax.marker]`, `r[asciidoc.syntax.inline-ignored]`,
+`r[asciidoc.duplicates.same-file]`, `r[asciidoc.duplicates.cross-file]`,
+`r[asciidoc.blocks.listing]`, `r[asciidoc.frontmatter.attributes]`,
+`r[asciidoc.html.div]`, `r[asciidoc.html.anchor]`, `r[asciidoc.html.link]` —
+parallel to the existing `markdown.*` rules.
+
+### 2.2 Parser choice
+
+Typst used `arborium-typst` (tree-sitter). Use the **same approach** for
+AsciiDoc for symmetry with #185: `arborium` already wraps tree-sitter
+grammars, and a `tree-sitter-asciidoc` grammar exists. Add
+`arborium-asciidoc` to the workspace alongside `arborium-typst`. If that
+grammar is missing or broken in practice, fall back to a minimal hand-rolled
+parser — AsciiDoc's requirement-extraction subset (headings, paragraphs,
+quoted blocks, listing blocks, comments, attribute entries) is small enough
+to parse in ~300 lines, and the maintainer already accepted a hand-rolled
+approach for Markdown's own text-based scanner. **Recommend tree-sitter**;
+note the fallback in the PR description.
+
+Heavy asciidoc rendering deps (if we end up using, e.g., `asciidork-*` as a
+Phase-2 "pretty HTML" backend) go behind a Cargo feature
+`asciidoc-spec` mirroring `typst-spec`. Phase 1 can render a `<pre>`
+placeholder the way `spec::typst::parse` does in PR #185 (when `typst-spec`
+is off) — this keeps the initial PR reviewable and unblocks everything
+downstream; a nicer renderer can land as a follow-up.
+
+### 2.3 Shape of `spec/asciidoc.rs`
+
+Copy the file layout from PR #185's `spec/typst.rs` exactly:
+
+```rust
+// crates/tracey-core/src/spec/asciidoc.rs
+
+pub struct RenderCtx<'a> {
+    pub badge_for: &'a (dyn Fn(&ReqDefinition) -> (String, String) + Sync),
+}
+
+#[cfg_attr(not(feature = "asciidoc-spec"), allow(unused_variables))]
+pub async fn render_display(
+    content: &str,
+    source_path: &std::path::Path,
+    ctx: &RenderCtx<'_>,
+    alloc: &mut SlugAllocator,
+    // Include-resolution deps (empty in v1; kept for API symmetry with typst)
+    deps: &mut std::collections::HashSet<std::path::PathBuf>,
+) -> eyre::Result<SpecDoc>;
+
+// Called by the parse_spec dispatcher — cheap path, no "pretty" rendering.
+pub(super) async fn parse(content: &str) -> eyre::Result<SpecDoc>;
+pub(super) fn diff_inline(old: &str, new: &str) -> Option<String>;
+pub(super) fn parse_weight(content: &str) -> i32;
+pub(super) fn extract_marker_prefix(content: &str, span: SourceSpan) -> Option<String>;
+pub(super) fn id_range_in_marker(marker_str: &str) -> eyre::Result<std::ops::Range<usize>>;
+```
+
+Every caller already uses these names by dispatching through `SpecFormat`.
+
+### 2.4 Integration points we touch
+
+All of these are *already* format-aware in PR #185. Our work here is just
+adding the AsciiDoc arms; if #185 isn't merged we're adding the same
+plumbing #185 added.
+
+| File | What changes |
+|---|---|
+| `crates/tracey-core/src/spec/mod.rs` | Add `AsciiDoc` variant to `SpecFormat`; add `"adoc" \| "asciidoc" \| "asc"` to `from_ext` and `SPEC_EXTENSIONS`; add dispatch arms in `parse_spec`, `diff_inline`, `parse_weight`, `extract_marker_prefix`, `id_range_in_marker`. Add `mod asciidoc; pub mod asciidoc;` (or `mod asciidoc; pub(crate) mod asciidoc;` — match #185's `pub mod typst;` so `tracey::data` can reach `spec::asciidoc::render_display` and `RenderCtx`). |
+| `crates/tracey-core/src/spec/asciidoc.rs` | New file per §2.3. |
+| `crates/tracey-core/Cargo.toml` | Add `arborium-asciidoc` (or chosen parser) to dependencies. If a heavier HTML renderer is used, add optional deps behind `asciidoc-spec` feature. |
+| `crates/tracey-core/src/lib.rs` | No change if #185 already re-exports the spec module; otherwise replicate #185's re-exports. |
+| `crates/tracey/src/data.rs` `load_spec_content` | Add `SpecFormat::AsciiDoc => { … }` arm next to the `Typst` arm (currently ~line 2895 in #185's diff). The arm mirrors the Typst arm: for each file call `spec::asciidoc::render_display` with a `RenderCtx` whose `badge_for` closure calls the already-extracted `rule_coverage_badge_html` helper. Reuse the same `SlugAllocator` threaded through markdown runs. No `deps` tracking needed in v1 — pass a throwaway `HashSet` (or only do include-tracking if the parser supports it). |
+| `crates/tracey/src/data.rs` `devicon_class` | Add `"adoc" \| "asciidoc" => Some("devicon-asciidoctor-original")` (or a sensible fallback — devicon may not ship an AsciiDoc icon; pick from the existing set). |
+| `crates/tracey/src/search.rs` | Add `"asciidoc"` to the `format_str` match and its reverse (`"asciidoc" => Some(SpecFormat::AsciiDoc)`). |
+| `crates/tracey/src/daemon/service.rs` `arborium_language` | Add `"adoc" \| "asciidoc" => Some("asciidoc")`. |
+| `crates/tracey/src/bump.rs` | No code change needed — already dispatches via `SpecFormat::from_path`. Only update the pathway that currently defaults to `SpecFormat::Markdown` on `unwrap_or` if we want AsciiDoc files to be picked up when their path-extension classification somehow fails (it won't, so leave as-is). |
+| `crates/tracey/src/daemon/service.rs` (the LSP-ish handlers using `is_spec_extension` / `SpecFormat::from_path`) | No code change — already format-agnostic in #185. |
+| `crates/tracey/src/daemon/watcher.rs` | No code change — purely glob-driven. A spec `include` of `**/*.adoc` just works. Add a unit test case. |
+| `crates/tracey/src/bridge/lsp.rs` | No code change — uses `is_spec_extension`. |
+| `crates/tracey-config/src/lib.rs` | Update the `SpecConfig::include` doc comment to mention `*.adoc` as another example. No schema change. If any AsciiDoc-specific attributes need config (e.g. attribute-set files, include search dirs), add an optional field symmetric to #185's `typst_package_path`. |
+| `README.md`, `README.md.in`, `docs/content/guide/writing-specs.md`, `docs/content/guide/getting-started.md`, `docs/content/spec/tracey.md`, `crates/tracey/skill/references/tracey-spec.md` | Mention AsciiDoc alongside Markdown. Add the `asciidoc.*` self-spec rules. |
+
+---
+
+## 3. Design notes borrowed directly from PR #185
+
+These are the non-obvious decisions #185 already made. Do not re-litigate;
+just follow them.
+
+- **`SlugAllocator` is threaded through the whole render, not per-format.**
+  `load_spec_content` owns a single allocator and passes `&mut` into each
+  per-format renderer. This is how heading anchors stay unique when a spec
+  mixes formats. The allocator also normalises the `r--` requirement-anchor
+  prefix so a `## Request` heading slug never collides with an
+  `r[request]` req anchor. The AsciiDoc backend MUST call
+  `alloc.alloc(base_slug)` for every heading and patch its HTML accordingly
+  (see #185's in-place `replacen` on `<hN id="…">`).
+
+- **`REQ_ANCHOR_PREFIX = "r--"` is THE contract.** Every backend emits
+  `anchor_id = format!("r--{id}")` in `ReqDefinition::anchor_id`. The
+  dashboard, static export (`bridge/export.rs`), and inline-code links
+  (`TraceyInlineCodeHandler`) all use `req_anchor_id()`. Do not deviate.
+
+- **`rule_coverage_badge_html` is the shared badge renderer.** #185 lifted
+  it out of `TraceyRuleHandler::start` into a free function that takes
+  `(&ReqDefinition, Option<&RuleCoverage>, &str source_file, &str spec_name,
+  &str impl_name) -> (String open, String close)`. AsciiDoc's `RenderCtx`
+  should delegate to this — do not reimplement badges.
+
+- **Two-path rendering (cheap vs. pretty) with a feature gate.** #185's
+  `spec::typst::parse` returns a `<pre class="typst-placeholder">`
+  placeholder; `render_display` (feature-gated on `typst-spec`) does the
+  real HTML compile. Follow the same pattern if pretty AsciiDoc rendering
+  needs a heavy dependency. Make `asciidoc-spec` default-on in the
+  binary build, off in library consumers.
+
+- **`SpecFormat` is `#[non_exhaustive]`** and `load_spec_content` has an
+  explicit `_ => eyre::bail!("rendering not implemented for spec format
+  {run_fmt:?}")` arm. #185 says this is deliberate: future formats must be
+  explicitly opted into the renderer before they can show up in the
+  dashboard. Preserve that arm. Our change replaces that `bail!` *only* for
+  the `AsciiDoc` variant, not globally.
+
+- **Run-partitioning in `load_spec_content`.** #185 partitions the
+  sorted-by-weight file list into **runs of consecutive same-format
+  files**. Markdown runs are concatenated and rendered once (so marq's
+  hierarchical heading-ids still span the whole run). Typst files render
+  one-at-a-time. **AsciiDoc should render one-at-a-time** like Typst unless
+  there is a concrete reason to concatenate — asciidoc documents don't
+  benefit from shared-heading-hierarchy the way marq markdown does, and
+  one-at-a-time rendering keeps the code simpler.
+
+- **`ExtractedRule.format` and `search::RuleEntry.format`.** #185 adds
+  these. Set them to `SpecFormat::AsciiDoc` in the extraction loop (see
+  `extract_spec_rules_cached` in `data.rs` and `load_rules_from_glob` in
+  `lib.rs`).
+
+- **Historical diff uses the current path's format** (see `load_previous_
+  rule_text_from_git`). #185 documents the known limitation: cross-format
+  renames (e.g. `spec.md` → `spec.adoc`) will silently miss. This is the
+  same limitation for AsciiDoc — call it out in a comment, don't try to fix.
+
+---
+
+## 4. Implementation order (3–4 commits, each reviewable)
+
+### Commit 1 — `spec::asciidoc` module stub + variant
+
+- Add `SpecFormat::AsciiDoc` to `spec/mod.rs` (extension list, `from_ext`,
+  dispatch arms).
+- Add `crates/tracey-core/src/spec/asciidoc.rs` with:
+  - `parse` returning a minimal `SpecDoc` (no reqs, `<pre>` placeholder).
+  - `diff_inline`, `parse_weight`, `extract_marker_prefix`,
+    `id_range_in_marker` — each sufficient to pass the mirror of the
+    existing markdown/typst tests in `spec/mod.rs`.
+- Update unit tests in `spec/mod.rs` to cover AsciiDoc extensions, anchor
+  round-trip, `from_path`, and `is_spec_extension`.
+- **No downstream callers change.** Everything still dispatches through
+  `SpecFormat::from_path` and gets a valid-but-empty doc for `.adoc` files.
+  The binary compiles; existing tests still pass.
+
+### Commit 2 — Real parser (reqs, headings, paragraphs, masks)
+
+- Wire `arborium-asciidoc` (or the hand-rolled parser) in
+  `spec/asciidoc.rs::parse`. Produce:
+  - `reqs: Vec<ReqDefinition>` with proper `span`, `marker_span`,
+    `anchor_id = req_anchor_id(&id)`, `line`, `raw`.
+  - `elements: Vec<DocElement>` in document order.
+  - `headings: Vec<Heading>` with deterministic base slugs (the
+    `SlugAllocator` in `data.rs` will globalise them).
+  - `inline_code_spans` from monospace/backtick spans.
+  - `<pre>` placeholder HTML (same pattern as `typst::parse` when
+    `typst-spec` is off).
+- Implement the mask logic for listing blocks, literal blocks,
+  passthroughs, and comments so markers inside them are ignored (mirror of
+  `crates/tracey-core/src/markdown.rs::markdown_code_mask`).
+- **Downstream callers still don't change.** LSP operations (document
+  symbols, tokens, code lenses, inlay hints, document highlight) start
+  working for `.adoc` files automatically because they all just call
+  `parse_spec(fmt, content)` and walk `doc.reqs`.
+- `bump` / `pre_commit` start working for `.adoc` files automatically —
+  they already dispatch through `id_range_in_marker(fmt, …)` and
+  `rewrite_marker`.
+
+### Commit 3 — Dashboard rendering
+
+- Add `AsciiDoc` arm to `load_spec_content`'s `match run_fmt` block in
+  `crates/tracey/src/data.rs`, symmetric to the `Typst` arm.
+  - Construct a `tracey_core::spec::asciidoc::RenderCtx { badge_for: &|def|
+    rule_coverage_badge_html(def, coverage.get(&def.id.to_string()),
+    &abs_source_str, spec_name, impl_name) }`.
+  - Call `spec::asciidoc::render_display(content, &abs_source, &ctx, &mut
+    slug_alloc, &mut throwaway_deps).await?`.
+  - Append `SpecSection`, extend `all_elements` / `head_injections`.
+- Add `"adoc" | "asciidoc"` branches to `devicon_class` and
+  `arborium_language`.
+- Add `"asciidoc"` to `search.rs` format-string round-trip.
+
+### Commit 4 — Tests, docs, fixtures
+
+- New `crates/tracey/tests/fixtures-asciidoc/` mirroring
+  `fixtures-typst/`: `config.styx`, `spec.adoc`, sibling rust source.
+- New `crates/tracey/tests/asciidoc_spec_tests.rs` mirroring
+  `typst_spec_tests.rs`: parse, bump, LSP doc-symbols, inline diff,
+  end-to-end dashboard render.
+- Extend `watcher_tests.rs` with an `.adoc`-file edit case.
+- Update docs per §2.4 table.
+- Update the config help-text string in `data.rs` (currently
+  `docs/spec/**/*.{md,typ}` post-#185) to `docs/spec/**/*.{md,typ,adoc}`.
+
+---
+
+## 5. Coordinating with PR #185
+
+Two merge orders are possible; plan for both.
+
+**Scenario A — #185 merges first.** Straightforward. This plan becomes pure
+addition: one new variant, one new submodule, one new `match` arm, one new
+test file. No abstraction work to duplicate.
+
+**Scenario B — AsciiDoc PR ready before #185 merges.** Replicate #185's
+abstraction verbatim (as §1 describes). Do not rename. Do not "improve".
+Structure the AsciiDoc PR so it could logically stack on top of #185:
+
+- Commit 1 of the AsciiDoc PR should introduce *only* the shared
+  abstraction (the `spec/mod.rs` enum, helpers, `SlugAllocator`,
+  `req_anchor_id`, `rule_coverage_badge_html` extraction, `ExtractedRule.
+  format`, `search::RuleEntry.format`). That commit is byte-identical to
+  the equivalent commits in #185 — it's literally the same change. The
+  maintainer can merge whichever PR's abstraction-commit lands first; the
+  other PR deletes it on rebase.
+- Commits 2–4 add the AsciiDoc variant on top.
+
+Either way, do not invent a parallel abstraction. The maintainer of #185 is
+the same person who will review the AsciiDoc PR, and a competing design is
+how second-format PRs die.
+
+---
+
+## 6. Non-goals
+
+- Full Asciidoctor-Ruby feature parity (tables, admonitions, callouts,
+  conditionals, math, footnotes). Unsupported features pass through as
+  plain text. Add a `ParseWarning` for features we detect but ignore.
+- Following `include::` directives in v1 (parameter kept in the API for
+  symmetry, filled with an empty set).
+- AsciiDoc as a **source-code language** — source parsing is already
+  format-agnostic and isn't affected.
+- Migration tooling. Existing markdown specs stay markdown; AsciiDoc is
+  opt-in per spec via include patterns.
+
+---
+
+## 7. Open questions
+
+1. **`arborium-asciidoc` availability.** Confirm the crate exists and parses
+   the subset we need. If not, fall back to a hand-rolled parser (decide
+   before commit 2; note in PR description).
+2. **Devicon for AsciiDoc.** Check what devicon ships. If nothing clean,
+   reuse the markdown icon or a neutral file-code icon — don't block review
+   on this.
+3. **Should AsciiDoc participate in the `SlugAllocator` the same way as
+   Markdown, or does tree-sitter give us globally-unique IDs we can emit
+   directly?** Consult #185's Typst implementation — it uses the allocator;
+   do the same. Don't optimise prematurely.
+4. **Feature flag.** Is the AsciiDoc rendering backend heavy enough to
+   warrant `asciidoc-spec`, or can we compile it unconditionally? If tree-
+   sitter + a small renderer, probably unconditional. If we pull in
+   `asciidork-*`'s full rendering pipeline later, put *that* behind a flag
+   symmetric to `typst-spec`.
+
+---
+
+## 8. Reviewer checklist (mirror PR #185's expectations)
+
+- [ ] `SpecFormat::AsciiDoc` added with extension list, `from_ext`,
+      dispatch arms; no other enum consumer broken (all sites pattern-match
+      exhaustively via `#[non_exhaustive]` `_ =>` arms, so new variant
+      additions are backward-compatible).
+- [ ] `spec/asciidoc.rs` mirrors `spec/typst.rs` one-for-one: same public
+      signatures, same `RenderCtx` shape, same cheap/pretty split.
+- [ ] `rule_coverage_badge_html` reused, not reimplemented.
+- [ ] `SlugAllocator` threaded through the AsciiDoc render; heading ids are
+      globally unique across a mixed-format spec.
+- [ ] Every `anchor_id` emitted starts with `REQ_ANCHOR_PREFIX`.
+- [ ] `ExtractedRule.format`, `search::RuleEntry.format`, and the search
+      index format-string are populated.
+- [ ] `load_previous_rule_text_from_git` falls through correctly for
+      `.adoc` files.
+- [ ] Tests mirror the `typst_spec_tests.rs` coverage: parse, bump, LSP
+      operations, end-to-end render, watcher rebuild on edit.
+- [ ] New `asciidoc.*` self-spec rules added and covered in the fixtures.
+- [ ] `cargo clippy --all-targets --all-features` clean.
+- [ ] No reverts of #185 helpers; no parallel abstraction.

--- a/crates/tracey-config/src/lib.rs
+++ b/crates/tracey-config/src/lib.rs
@@ -33,8 +33,8 @@ pub struct SpecConfig {
     #[facet(default)]
     pub source_url: Option<String>,
 
-    /// Glob patterns for markdown spec files containing requirement definitions
-    /// e.g., "docs/spec/**/*.md"
+    /// Glob patterns for spec files (Markdown or AsciiDoc) containing requirement definitions.
+    /// e.g., "docs/spec/**/*.md" or "docs/spec/**/*.adoc"
     /// r[impl config.spec.include]
     #[facet(default)]
     pub include: Vec<String>,

--- a/crates/tracey-core/Cargo.toml
+++ b/crates/tracey-core/Cargo.toml
@@ -19,6 +19,14 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 default = ["walk", "parallel"]
 walk = ["dep:ignore", "dep:globset"]
 parallel = ["dep:rayon"]
+asciidoc-spec = [
+  "dep:asciidork-core",
+  "dep:asciidork-parser",
+  "dep:asciidork-ast",
+  "dep:asciidork-backend",
+  "dep:asciidork-dr-html-backend",
+  "dep:bumpalo",
+]
 reverse = [
   "dep:arborium",
   "dep:arborium-rust",
@@ -64,6 +72,12 @@ pulldown-cmark = { workspace = true }
 ignore = { workspace = true, optional = true }
 globset = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
+asciidork-core = { workspace = true, optional = true }
+asciidork-parser = { workspace = true, optional = true }
+asciidork-ast = { workspace = true, optional = true }
+asciidork-backend = { workspace = true, optional = true }
+asciidork-dr-html-backend = { workspace = true, optional = true }
+bumpalo = { workspace = true, optional = true }
 arborium = { workspace = true, optional = true }
 arborium-rust = { workspace = true, optional = true }
 arborium-swift = { workspace = true, optional = true }
@@ -96,3 +110,6 @@ arborium-ocaml = { workspace = true, optional = true }
 arborium-bash = { workspace = true, optional = true }
 arborium-nix = { workspace = true, optional = true }
 arborium-lean = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/tracey-core/src/lib.rs
+++ b/crates/tracey-core/src/lib.rs
@@ -10,7 +10,7 @@ mod markdown;
 mod positions;
 mod rule_id;
 mod sources;
-mod spec;
+pub mod spec;
 
 #[cfg(feature = "reverse")]
 pub mod code_units;

--- a/crates/tracey-core/src/spec.rs
+++ b/crates/tracey-core/src/spec.rs
@@ -1,3 +1,0 @@
-//! Req definitions re-exported from marq
-
-pub use marq::ReqDefinition;

--- a/crates/tracey-core/src/spec/asciidoc/ast_walk.rs
+++ b/crates/tracey-core/src/spec/asciidoc/ast_walk.rs
@@ -1,0 +1,336 @@
+//! AST walk for asciidork documents: extract requirements, headings, inline code spans.
+
+use std::collections::HashSet;
+
+use asciidork_ast::{
+    AttrValue, Block, BlockContent, BlockContext, DocContent, Document, Inline, InlineNodes,
+    ReadAttr, Section,
+};
+use marq::{
+    DocElement, Heading, InlineCodeSpan, Paragraph, ReqDefinition, ReqMetadata, SourceSpan,
+};
+
+use crate::spec::{SlugAllocator, req_anchor_id};
+
+/// Result of walking the asciidork AST.
+pub struct WalkResult {
+    pub reqs: Vec<ReqDefinition>,
+    pub headings: Vec<Heading>,
+    pub elements: Vec<DocElement>,
+    pub inline_code_spans: Vec<InlineCodeSpan>,
+    pub weight: i32,
+    /// Mapping from asciidork section IDs to our allocated slugs.
+    /// Each entry is `(asciidork_id, our_slug)`, in document order.
+    /// Used to post-process the rendered HTML heading `id=` attributes.
+    pub section_id_map: Vec<(String, String)>,
+}
+
+/// Walk the asciidork document AST to extract spec data.
+pub fn walk<'arena>(
+    doc: &Document<'arena>,
+    source: &str,
+    alloc: &mut SlugAllocator,
+) -> eyre::Result<WalkResult> {
+    let mut result = WalkResult {
+        reqs: Vec::new(),
+        headings: Vec::new(),
+        elements: Vec::new(),
+        inline_code_spans: Vec::new(),
+        weight: 0,
+        section_id_map: Vec::new(),
+    };
+
+    // Extract weight from document header attributes (:weight: N syntax)
+    if let Some(AttrValue::String(w)) = doc.meta.get("weight") {
+        result.weight = w.trim().parse::<i32>().unwrap_or(0);
+    }
+
+    let mut seen_bases = HashSet::new();
+
+    match &doc.content {
+        DocContent::Blocks(blocks) => {
+            walk_blocks(blocks, source, alloc, &mut result, &mut seen_bases)?;
+        }
+        DocContent::Sections(sectioned) => {
+            if let Some(preamble) = &sectioned.preamble {
+                walk_blocks(preamble, source, alloc, &mut result, &mut seen_bases)?;
+            }
+            for section in &sectioned.sections {
+                walk_section(section, source, alloc, &mut result, &mut seen_bases)?;
+            }
+        }
+        DocContent::Parts(_) => {}
+    }
+
+    Ok(result)
+}
+
+fn walk_blocks<'arena>(
+    blocks: &[Block<'arena>],
+    source: &str,
+    alloc: &mut SlugAllocator,
+    result: &mut WalkResult,
+    seen_bases: &mut HashSet<String>,
+) -> eyre::Result<()> {
+    for block in blocks {
+        walk_block(block, source, alloc, result, seen_bases)?;
+    }
+    Ok(())
+}
+
+fn walk_section<'arena>(
+    section: &Section<'arena>,
+    source: &str,
+    alloc: &mut SlugAllocator,
+    result: &mut WalkResult,
+    seen_bases: &mut HashSet<String>,
+) -> eyre::Result<()> {
+    let title = section.heading.plain_text().join("");
+    let base_slug = marq::slugify(&title);
+    let our_slug = alloc.alloc(&base_slug);
+
+    if let Some(adoc_id) = &section.id {
+        result.section_id_map.push((adoc_id.as_str().to_string(), our_slug.clone()));
+    }
+
+    let start_pos = section.loc.start_pos as usize;
+    let line = byte_offset_to_line(source, start_pos);
+
+    let heading = Heading {
+        title: title.clone(),
+        id: our_slug.clone(),
+        level: section.level,
+        line,
+    };
+    result.headings.push(heading.clone());
+    result.elements.push(DocElement::Heading(heading));
+
+    collect_spans_from_inlines(&section.heading, &mut result.inline_code_spans);
+    walk_blocks(&section.blocks, source, alloc, result, seen_bases)?;
+    Ok(())
+}
+
+fn walk_block<'arena>(
+    block: &Block<'arena>,
+    source: &str,
+    alloc: &mut SlugAllocator,
+    result: &mut WalkResult,
+    seen_bases: &mut HashSet<String>,
+) -> eyre::Result<()> {
+    match &block.content {
+        BlockContent::Simple(inlines) if block.context == BlockContext::Paragraph => {
+            walk_paragraph(inlines, source, result, seen_bases)?;
+        }
+        BlockContent::Simple(inlines) => {
+            collect_spans_from_inlines(inlines, &mut result.inline_code_spans);
+        }
+        BlockContent::Section(section) => {
+            walk_section(section, source, alloc, result, seen_bases)?;
+        }
+        BlockContent::Compound(inner_blocks) => {
+            walk_blocks(inner_blocks, source, alloc, result, seen_bases)?;
+        }
+        BlockContent::DocumentAttribute(key, AttrValue::String(w)) if key == "weight" => {
+            result.weight = w.trim().parse::<i32>().unwrap_or(0);
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn walk_paragraph<'arena>(
+    inlines: &InlineNodes<'arena>,
+    source: &str,
+    result: &mut WalkResult,
+    seen_bases: &mut HashSet<String>,
+) -> eyre::Result<()> {
+    collect_spans_from_inlines(inlines, &mut result.inline_code_spans);
+
+    let Some(first) = inlines.first() else {
+        result.elements.push(DocElement::Paragraph(Paragraph { line: 0, offset: 0 }));
+        return Ok(());
+    };
+
+    let first_text = match &first.content {
+        Inline::Text(s) => s.as_str(),
+        _ => {
+            let line = byte_offset_to_line(source, first.loc.start as usize);
+            result.elements.push(DocElement::Paragraph(Paragraph { line, offset: 0 }));
+            return Ok(());
+        }
+    };
+
+    let Some((_, id_str, marker_end)) = parse_req_leading_marker(first_text) else {
+        let line = byte_offset_to_line(source, first.loc.start as usize);
+        result.elements.push(DocElement::Paragraph(Paragraph { line, offset: 0 }));
+        return Ok(());
+    };
+
+    let Some((req_id, metadata)) = parse_req_marker_inner(id_str) else {
+        let line = byte_offset_to_line(source, first.loc.start as usize);
+        result.elements.push(DocElement::Paragraph(Paragraph { line, offset: 0 }));
+        return Ok(());
+    };
+
+    if seen_bases.contains(&req_id.base) {
+        eyre::bail!("Duplicate requirement '{}' in AsciiDoc file", req_id.base);
+    }
+    seen_bases.insert(req_id.base.clone());
+
+    let span_start = first.loc.start as usize;
+    let span_end = inlines
+        .last_loc()
+        .map_or(span_start, |l| l.end as usize);
+    let line = byte_offset_to_line(source, span_start);
+
+    let marker_len = marker_end + 1;
+    let anchor = req_anchor_id(&req_id.to_string());
+
+    // Build raw body from the source span (preserves newlines)
+    let block_source = source.get(span_start..span_end.min(source.len())).unwrap_or("");
+    let after_marker = block_source.get(marker_len..).unwrap_or("").trim_start_matches([' ', '\t', '\n', '\r']);
+    let raw = after_marker.trim_end().to_string();
+
+    let req_html = render_req_body_html(&raw);
+
+    let req = ReqDefinition {
+        id: req_id,
+        anchor_id: anchor,
+        marker_span: SourceSpan {
+            offset: span_start,
+            length: marker_len,
+        },
+        span: SourceSpan {
+            offset: span_start,
+            length: span_end.saturating_sub(span_start),
+        },
+        line,
+        metadata,
+        raw,
+        html: req_html,
+    };
+
+    result.elements.push(DocElement::Req(req.clone()));
+    result.reqs.push(req);
+    Ok(())
+}
+
+/// Collect inline code spans (backtick / mono spans) from inline nodes.
+fn collect_spans_from_inlines<'arena>(
+    inlines: &InlineNodes<'arena>,
+    spans: &mut Vec<InlineCodeSpan>,
+) {
+    for node in inlines.iter() {
+        match &node.content {
+            Inline::Span(asciidork_ast::SpanKind::LitMono, _, inner)
+            | Inline::Span(asciidork_ast::SpanKind::Mono, _, inner) => {
+                let content = inner.plain_text().join("");
+                let start = node.loc.start as usize;
+                let end = node.loc.end as usize;
+                spans.push(InlineCodeSpan {
+                    content,
+                    span: SourceSpan {
+                        offset: start,
+                        length: end.saturating_sub(start),
+                    },
+                });
+                collect_spans_from_inlines(inner, spans);
+            }
+            Inline::Span(_, _, inner) => {
+                collect_spans_from_inlines(inner, spans);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Convert a byte offset into a 1-based line number.
+pub fn byte_offset_to_line(source: &str, offset: usize) -> usize {
+    source[..offset.min(source.len())].matches('\n').count() + 1
+}
+
+/// Render requirement body as HTML (`<p>` wrapped plain text).
+pub fn render_req_body_html(raw: &str) -> String {
+    if raw.is_empty() {
+        return String::new();
+    }
+    let mut html = String::new();
+    for para in raw.split("\n\n") {
+        let trimmed = para.trim();
+        if !trimmed.is_empty() {
+            html.push_str("<p>");
+            html.push_str(&html_escape(trimmed));
+            html.push_str("</p>\n");
+        }
+    }
+    html
+}
+
+/// Parse a requirement leading marker at the start of a line.
+///
+/// Returns `(prefix, id_str, marker_end_offset)` where `marker_end_offset`
+/// is the index of the closing `]` (inclusive).
+pub fn parse_req_leading_marker(line: &str) -> Option<(&str, &str, usize)> {
+    let mut prefix_len = 0usize;
+    for ch in line.chars() {
+        if ch.is_ascii_lowercase() || ch.is_ascii_digit() {
+            prefix_len += ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+    if prefix_len == 0 || line.as_bytes().get(prefix_len) != Some(&b'[') {
+        return None;
+    }
+    let close = line.find(']')?;
+    if close <= prefix_len + 1 {
+        return None; // empty brackets
+    }
+    let prefix = &line[..prefix_len];
+    let id_str = &line[prefix_len + 1..close];
+    Some((prefix, id_str, close))
+}
+
+/// Parse the inner content of a requirement marker (the text between `[` and `]`).
+pub fn parse_req_marker_inner(inner: &str) -> Option<(marq::RuleId, ReqMetadata)> {
+    let inner = inner.trim();
+    let (id_part, attrs_str) = match inner.find(' ') {
+        Some(idx) => (&inner[..idx], inner[idx + 1..].trim()),
+        None => (inner, ""),
+    };
+    let req_id = marq::parse_rule_id(id_part)?;
+    let mut metadata = ReqMetadata::default();
+    if !attrs_str.is_empty() {
+        for attr in attrs_str.split_whitespace() {
+            if let Some((key, value)) = attr.split_once('=') {
+                match key {
+                    "status" => metadata.status = marq::ReqStatus::parse(value),
+                    "level" => metadata.level = marq::ReqLevel::parse(value),
+                    "since" => metadata.since = Some(value.to_string()),
+                    "until" => metadata.until = Some(value.to_string()),
+                    "tags" => {
+                        metadata.tags =
+                            value.split(',').map(|s| s.trim().to_string()).collect()
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    Some((req_id, metadata))
+}
+
+fn html_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            c => out.push(c),
+        }
+    }
+    out
+}

--- a/crates/tracey-core/src/spec/asciidoc/mod.rs
+++ b/crates/tracey-core/src/spec/asciidoc/mod.rs
@@ -1,0 +1,314 @@
+//! AsciiDoc spec backend — asciidork-parser based.
+//!
+//! Two-pass implementation:
+//! 1. Walk the asciidork AST to extract requirements, headings, and inline code spans.
+//! 2. Convert to HTML via `asciidork_dr_html_backend::convert()`, then post-process
+//!    to inject `<div class="req-container">` wrappers and fix heading IDs.
+//!
+//! The public API matches the hand-rolled predecessor exactly — only the internals change.
+
+#[cfg(feature = "asciidoc-spec")]
+mod ast_walk;
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use marq::{ReqDefinition, SourceSpan};
+
+use super::{SlugAllocator, SpecDoc};
+#[cfg(feature = "asciidoc-spec")]
+use super::req_anchor_id;
+
+// ============================================================================
+// Public context for dashboard rendering
+// ============================================================================
+
+/// Context for coverage-aware AsciiDoc rendering.
+pub struct RenderCtx<'a> {
+    /// Closure returning `(open_html, close_html)` for each requirement container.
+    pub badge_for: &'a (dyn Fn(&ReqDefinition) -> (String, String) + Sync),
+}
+
+// ============================================================================
+// Public entry points
+// ============================================================================
+
+// r[impl asciidoc.html.div]
+// r[impl asciidoc.html.anchor]
+pub(super) async fn parse(content: &str) -> eyre::Result<SpecDoc> {
+    #[cfg(feature = "asciidoc-spec")]
+    {
+        let req_renderer = |req: &ReqDefinition| {
+            let anchor = req_anchor_id(&req.id.to_string());
+            let open = format!(
+                r#"<div class="req-container req-uncovered" id="{anchor}" data-br="{start}-{end}"><div class="req-content">"#,
+                anchor = html_escape(&anchor),
+                start = req.span.offset,
+                end = req.span.offset + req.span.length,
+            );
+            (open, "</div>\n</div>".to_string())
+        };
+        parse_sync(content, &req_renderer, None)
+    }
+    #[cfg(not(feature = "asciidoc-spec"))]
+    {
+        Ok(placeholder_doc(content))
+    }
+}
+
+// r[impl asciidoc.html.link]
+pub async fn render_display(
+    content: &str,
+    _source_path: &std::path::Path,
+    _ctx: &RenderCtx<'_>,
+    _alloc: &mut SlugAllocator,
+    _deps: &mut HashSet<PathBuf>,
+) -> eyre::Result<SpecDoc> {
+    #[cfg(feature = "asciidoc-spec")]
+    {
+        parse_sync(content, _ctx.badge_for, Some(_alloc))
+    }
+    #[cfg(not(feature = "asciidoc-spec"))]
+    {
+        Ok(placeholder_doc(content))
+    }
+}
+
+// ============================================================================
+// Per-format helpers (unchanged from predecessor)
+// ============================================================================
+
+pub(super) fn diff_inline(old: &str, new: &str) -> Option<String> {
+    Some(marq::diff_markdown_inline(old, new))
+}
+
+// r[impl asciidoc.frontmatter.attributes]
+pub(super) fn parse_weight(content: &str) -> i32 {
+    // YAML/TOML frontmatter first
+    if let Ok((fm, _)) = marq::parse_frontmatter(content) {
+        if fm.weight != 0 {
+            return fm.weight;
+        }
+    }
+    // AsciiDoc `:weight: N` document attribute (line scan, pre-title only)
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('=') {
+            break;
+        }
+        if let Some(w) = line
+            .strip_prefix(":weight:")
+            .and_then(|r| r.trim().parse::<i32>().ok())
+        {
+            return w;
+        }
+    }
+    0
+}
+
+pub(super) fn extract_marker_prefix(content: &str, span: SourceSpan) -> Option<String> {
+    super::common_extract_marker_prefix(content, span)
+}
+
+pub(super) fn id_range_in_marker(marker_str: &str) -> eyre::Result<std::ops::Range<usize>> {
+    super::common_id_range_in_marker(marker_str)
+}
+
+// ============================================================================
+// Core two-pass implementation
+// ============================================================================
+
+#[cfg(feature = "asciidoc-spec")]
+fn parse_sync(
+    content: &str,
+    req_renderer: &dyn Fn(&ReqDefinition) -> (String, String),
+    alloc: Option<&mut SlugAllocator>,
+) -> eyre::Result<SpecDoc> {
+    use asciidork_core::JobSettings;
+    use asciidork_parser::prelude::*;
+    use bumpalo::Bump;
+
+    let arena = Bump::new();
+    let mut parser = Parser::from_str(content, SourceFile::Tmp, &arena);
+    // Non-strict: cross-file xrefs (<<anchor-in-other-file>>) are unresolvable
+    // during per-file parsing but valid at page render time since all spec
+    // files share one HTML page. Suppress parse errors and let them render
+    // as <a href="#anchor"> links instead.
+    parser.apply_job_settings(JobSettings { strict: false, ..JobSettings::default() });
+    let parsed = parser
+        .parse()
+        .map_err(|e| eyre::eyre!("AsciiDoc parse error: {:?}", e))?;
+
+    let mut owned_alloc = SlugAllocator::new();
+    let alloc_ref = alloc.unwrap_or(&mut owned_alloc);
+
+    // Pass 1: walk AST for extraction
+    let walk = ast_walk::walk(&parsed.document, content, alloc_ref)?;
+
+    // Pass 2: render HTML and post-process
+    let html = asciidork_dr_html_backend::convert(parsed.document)
+        .map_err(|e| eyre::eyre!("AsciiDoc HTML render error: {:?}", e))?;
+
+    let content_html = extract_content_html(&html);
+    let content_html = post_process_html(content_html, content, &walk, req_renderer);
+
+    Ok(marq::Document {
+        raw_metadata: None,
+        metadata_format: None,
+        frontmatter: None,
+        html: content_html,
+        headings: walk.headings,
+        reqs: walk.reqs,
+        code_samples: Vec::new(),
+        elements: walk.elements,
+        head_injections: Vec::new(),
+        inline_code_spans: walk.inline_code_spans,
+    })
+}
+
+/// Extract the inner HTML of `<div id="content">` from the full asciidork output.
+///
+/// Returns the content between `<div id="content">` and `<div id="footer">`,
+/// or the full HTML if the pattern is not found.
+#[cfg(feature = "asciidoc-spec")]
+fn extract_content_html(full_html: &str) -> &str {
+    let content_marker = r#"<div id="content">"#;
+    let footer_marker = r#"<div id="footer">"#;
+
+    let Some(content_start) = full_html.find(content_marker) else {
+        return full_html;
+    };
+    let inner_start = content_start + content_marker.len();
+
+    let Some(footer_start) = full_html[inner_start..].find(footer_marker) else {
+        // No footer — take everything after content marker until </body>
+        if let Some(body_end) = full_html[inner_start..].find("</body>") {
+            let raw = &full_html[inner_start..inner_start + body_end];
+            return raw.strip_suffix("</div>").unwrap_or(raw);
+        }
+        return &full_html[inner_start..];
+    };
+
+    // Strip exactly the one trailing </div> that closes <div id="content">
+    let before_footer = &full_html[inner_start..inner_start + footer_start];
+    before_footer.strip_suffix("</div>").unwrap_or(before_footer)
+}
+
+/// Post-process the asciidork HTML:
+/// 1. Replace req paragraphs with req-container divs.
+/// 2. Replace asciidork heading IDs with our SlugAllocator-assigned slugs.
+#[cfg(feature = "asciidoc-spec")]
+fn post_process_html(
+    content_html: &str,
+    source: &str,
+    walk: &ast_walk::WalkResult,
+    req_renderer: &dyn Fn(&ReqDefinition) -> (String, String),
+) -> String {
+    let mut html = content_html.to_string();
+
+    // Step 1: inject req-container wrappers
+    for req in &walk.reqs {
+        let marker_text = source
+            .get(req.marker_span.offset..req.marker_span.offset + req.marker_span.length)
+            .unwrap_or("");
+        if !marker_text.is_empty() {
+            html = replace_req_paragraph(&html, req, marker_text, req_renderer);
+        }
+    }
+
+    // Step 2: replace asciidork section IDs with our slugs
+    for (adoc_id, our_slug) in &walk.section_id_map {
+        // Replace id="ADOC_ID" with id="OUR_SLUG"
+        let from_id = format!(r#" id="{}""#, adoc_id);
+        let to_id = format!(r#" id="{}""#, our_slug);
+        html = html.replace(&from_id, &to_id);
+
+        // Replace href="#ADOC_ID" with href="#OUR_SLUG" (for sectanchors etc.)
+        let from_href = format!(" href=\"#{}\"", adoc_id);
+        let to_href = format!(" href=\"#{}\"", our_slug);
+        html = html.replace(&from_href, &to_href);
+    }
+
+    html
+}
+
+/// Replace a single requirement paragraph in the HTML with its req-container HTML.
+///
+/// Finds `<div class="paragraph"><p>MARKER_TEXT` and replaces the paragraph div
+/// with the output of `req_renderer(req)`.
+#[cfg(feature = "asciidoc-spec")]
+fn replace_req_paragraph(
+    html: &str,
+    req: &ReqDefinition,
+    marker_text: &str,
+    req_renderer: &dyn Fn(&ReqDefinition) -> (String, String),
+) -> String {
+    let search = format!(r#"<div class="paragraph"><p>{}"#, marker_text);
+
+    let Some(div_start) = html.find(&search) else {
+        return html.to_string();
+    };
+
+    let after_marker = &html[div_start + search.len()..];
+
+    let Some(body_end) = after_marker.find("</p></div>") else {
+        return html.to_string();
+    };
+
+    let body_in_html = &after_marker[..body_end];
+    // Strip leading space (the space asciidork puts between marker and body)
+    let body_in_html = body_in_html.strip_prefix(' ').unwrap_or(body_in_html);
+
+    let div_end = div_start + search.len() + body_end + "</p></div>".len();
+
+    let (open_html, close_html) = req_renderer(req);
+    let replacement = if body_in_html.is_empty() {
+        format!("{open_html}{close_html}")
+    } else {
+        format!("{open_html}<p>{body_in_html}</p>\n{close_html}")
+    };
+
+    let mut result = String::with_capacity(html.len());
+    result.push_str(&html[..div_start]);
+    result.push_str(&replacement);
+    result.push_str(&html[div_end..]);
+    result
+}
+
+// ============================================================================
+// Feature-off stub
+// ============================================================================
+
+#[cfg(not(feature = "asciidoc-spec"))]
+fn placeholder_doc(content: &str) -> SpecDoc {
+    marq::Document {
+        raw_metadata: None,
+        metadata_format: None,
+        frontmatter: None,
+        html: format!(
+            r#"<pre class="asciidoc-placeholder">{}</pre>"#,
+            html_escape(content)
+        ),
+        headings: Vec::new(),
+        reqs: Vec::new(),
+        code_samples: Vec::new(),
+        elements: Vec::new(),
+        head_injections: Vec::new(),
+        inline_code_spans: Vec::new(),
+    }
+}
+
+fn html_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            c => out.push(c),
+        }
+    }
+    out
+}

--- a/crates/tracey-core/src/spec/markdown.rs
+++ b/crates/tracey-core/src/spec/markdown.rs
@@ -1,0 +1,28 @@
+//! Markdown spec backend — thin delegation to marq.
+
+use crate::spec::SourceSpan;
+
+pub(super) async fn parse(content: &str) -> eyre::Result<super::SpecDoc> {
+    marq::render(content, &marq::RenderOptions::default())
+        .await
+        .map_err(|e| eyre::eyre!("markdown parse error: {}", e))
+}
+
+pub(super) fn diff_inline(old: &str, new: &str) -> Option<String> {
+    Some(marq::diff_markdown_inline(old, new))
+}
+
+pub(super) fn parse_weight(content: &str) -> i32 {
+    marq::parse_frontmatter(content)
+        .ok()
+        .and_then(|(fm, _)| Some(fm.weight))
+        .unwrap_or(0)
+}
+
+pub(super) fn extract_marker_prefix(content: &str, span: SourceSpan) -> Option<String> {
+    super::common_extract_marker_prefix(content, span)
+}
+
+pub(super) fn id_range_in_marker(marker_str: &str) -> eyre::Result<std::ops::Range<usize>> {
+    super::common_id_range_in_marker(marker_str)
+}

--- a/crates/tracey-core/src/spec/mod.rs
+++ b/crates/tracey-core/src/spec/mod.rs
@@ -1,0 +1,323 @@
+//! Multi-format spec file support.
+//!
+//! This module provides format-dispatched operations for spec files (Markdown, AsciiDoc).
+//! Both formats share the same `r[id]` marker syntax for requirement definitions.
+
+use std::ffi::OsStr;
+use std::ops::Range;
+use std::path::Path;
+
+pub mod asciidoc;
+mod markdown;
+
+// Re-export marq types as canonical spec types
+pub use marq::{DocElement, InlineCodeSpan, ReqDefinition, RuleId as SpecRuleId, SourceSpan};
+pub type SpecDoc = marq::Document;
+
+/// Supported spec file format.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SpecFormat {
+    Markdown,
+    AsciiDoc,
+}
+
+/// All file extensions recognized as spec files.
+pub const SPEC_EXTENSIONS: &[&str] = &["md", "markdown", "adoc", "asciidoc", "asc"];
+
+/// Returns true if the extension is a recognized spec file extension.
+pub fn is_spec_extension(ext: &OsStr) -> bool {
+    SPEC_EXTENSIONS.iter().any(|e| OsStr::new(e) == ext)
+}
+
+impl SpecFormat {
+    /// Determine format from file path extension.
+    pub fn from_path(p: &Path) -> Option<Self> {
+        p.extension().and_then(Self::from_ext)
+    }
+
+    /// Determine format from file extension.
+    pub fn from_ext(ext: &OsStr) -> Option<Self> {
+        match ext.to_str()? {
+            "md" | "markdown" => Some(SpecFormat::Markdown),
+            "adoc" | "asciidoc" | "asc" => Some(SpecFormat::AsciiDoc),
+            _ => None,
+        }
+    }
+
+    /// A stable lowercase string name for this format (for search indexes, logs).
+    pub fn as_str(self) -> &'static str {
+        #[allow(unreachable_patterns)]
+        match self {
+            SpecFormat::Markdown => "markdown",
+            SpecFormat::AsciiDoc => "asciidoc",
+            _ => "unknown",
+        }
+    }
+}
+
+/// HTML anchor prefix for requirement anchors.
+/// Every backend MUST use this prefix for `ReqDefinition::anchor_id`.
+pub const REQ_ANCHOR_PREFIX: &str = "r--";
+
+/// Compute the HTML anchor ID for a requirement ID string.
+pub fn req_anchor_id(id: &str) -> String {
+    format!("{}{}", REQ_ANCHOR_PREFIX, id)
+}
+
+/// Extract the requirement ID from an anchor ID (reverse of `req_anchor_id`).
+pub fn req_anchor_to_id(anchor: &str) -> Option<&str> {
+    anchor.strip_prefix(REQ_ANCHOR_PREFIX)
+}
+
+/// Slug allocator — ensures heading anchors are globally unique across a mixed-format spec.
+///
+/// Thread the same allocator through all per-file renderers in one `load_spec_content` call.
+pub struct SlugAllocator {
+    seen: std::collections::HashSet<String>,
+}
+
+impl Default for SlugAllocator {
+    fn default() -> Self {
+        Self {
+            seen: std::collections::HashSet::new(),
+        }
+    }
+}
+
+impl SlugAllocator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allocate a unique slug. Appends `-2`, `-3`, ... when `base` is already taken.
+    pub fn alloc(&mut self, base: &str) -> String {
+        if self.seen.insert(base.to_string()) {
+            return base.to_string();
+        }
+        let mut n = 2u32;
+        loop {
+            let candidate = format!("{}-{}", base, n);
+            if self.seen.insert(candidate.clone()) {
+                return candidate;
+            }
+            n += 1;
+        }
+    }
+}
+
+/// Parse a spec file to extract requirements, headings, and placeholder HTML.
+///
+/// This is the cheap path used by LSP, bump, and coverage extraction.
+/// It does not invoke coverage-aware rendering.
+pub async fn parse_spec(fmt: SpecFormat, content: &str) -> eyre::Result<SpecDoc> {
+    #[allow(unreachable_patterns)]
+    match fmt {
+        SpecFormat::Markdown => markdown::parse(content).await,
+        SpecFormat::AsciiDoc => asciidoc::parse(content).await,
+        _ => eyre::bail!("parse_spec not implemented for format {:?}", fmt),
+    }
+}
+
+/// Compute an inline diff between two versions of a spec rule's raw text.
+///
+/// Returns `None` if the format does not support inline diff.
+pub fn diff_inline(fmt: SpecFormat, old: &str, new: &str) -> Option<String> {
+    #[allow(unreachable_patterns)]
+    match fmt {
+        SpecFormat::Markdown => markdown::diff_inline(old, new),
+        SpecFormat::AsciiDoc => asciidoc::diff_inline(old, new),
+        _ => None,
+    }
+}
+
+/// Parse the sort weight from spec file content.
+///
+/// Markdown: reads TOML/YAML frontmatter `weight` field.
+/// AsciiDoc: reads `:weight: N` document attribute (or YAML/TOML frontmatter).
+pub fn parse_weight(fmt: SpecFormat, content: &str) -> i32 {
+    #[allow(unreachable_patterns)]
+    match fmt {
+        SpecFormat::Markdown => markdown::parse_weight(content),
+        SpecFormat::AsciiDoc => asciidoc::parse_weight(content),
+        _ => 0,
+    }
+}
+
+/// Extract the marker prefix from a requirement marker at the given byte span.
+///
+/// E.g., for `r[auth.login]` with `span` covering the whole marker, returns `"r"`.
+pub fn extract_marker_prefix(fmt: SpecFormat, content: &str, span: SourceSpan) -> Option<String> {
+    #[allow(unreachable_patterns)]
+    match fmt {
+        SpecFormat::Markdown => markdown::extract_marker_prefix(content, span),
+        SpecFormat::AsciiDoc => asciidoc::extract_marker_prefix(content, span),
+        _ => None,
+    }
+}
+
+/// Find the byte range of the ID within a marker string.
+///
+/// For `"r[auth.login+2]"`, returns `2..14` (the bytes of `auth.login+2`).
+pub fn id_range_in_marker(fmt: SpecFormat, marker_str: &str) -> eyre::Result<Range<usize>> {
+    #[allow(unreachable_patterns)]
+    match fmt {
+        SpecFormat::Markdown => markdown::id_range_in_marker(marker_str),
+        SpecFormat::AsciiDoc => asciidoc::id_range_in_marker(marker_str),
+        _ => eyre::bail!("id_range_in_marker not implemented for format {:?}", fmt),
+    }
+}
+
+/// Rewrite a marker string, replacing the ID at `id_range` with `base+new_ver`.
+///
+/// Format-independent: all formats share the `prefix[base+version]` marker syntax.
+pub fn rewrite_marker(
+    marker_str: &str,
+    id_range: Range<usize>,
+    base: &str,
+    new_ver: u32,
+) -> eyre::Result<String> {
+    if id_range.end > marker_str.len() {
+        eyre::bail!(
+            "id_range {:?} out of bounds for marker {:?}",
+            id_range,
+            marker_str
+        );
+    }
+    let new_id = if new_ver == 1 {
+        base.to_string()
+    } else {
+        format!("{}+{}", base, new_ver)
+    };
+    let mut result =
+        String::with_capacity(marker_str.len() - (id_range.end - id_range.start) + new_id.len());
+    result.push_str(&marker_str[..id_range.start]);
+    result.push_str(&new_id);
+    result.push_str(&marker_str[id_range.end..]);
+    Ok(result)
+}
+
+/// Common implementation for marker prefix extraction (identical for all formats).
+pub(crate) fn common_extract_marker_prefix(content: &str, span: SourceSpan) -> Option<String> {
+    let start = span.offset;
+    let end = start.checked_add(span.length)?;
+    let marker = content.get(start..end)?;
+    let bracket = marker.find('[')?;
+    let prefix = marker[..bracket].trim();
+    if prefix.is_empty() {
+        return None;
+    }
+    Some(prefix.to_string())
+}
+
+/// Common implementation for ID range extraction (identical for all formats).
+pub(crate) fn common_id_range_in_marker(marker_str: &str) -> eyre::Result<Range<usize>> {
+    let open = marker_str
+        .find('[')
+        .ok_or_else(|| eyre::eyre!("no '[' in marker: {:?}", marker_str))?;
+    let close = marker_str
+        .rfind(']')
+        .ok_or_else(|| eyre::eyre!("no ']' in marker: {:?}", marker_str))?;
+    if close <= open + 1 {
+        eyre::bail!("empty or malformed marker: {:?}", marker_str);
+    }
+    Ok(open + 1..close)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+    use std::path::Path;
+
+    #[test]
+    fn test_is_spec_extension() {
+        assert!(is_spec_extension(OsStr::new("md")));
+        assert!(is_spec_extension(OsStr::new("markdown")));
+        assert!(is_spec_extension(OsStr::new("adoc")));
+        assert!(is_spec_extension(OsStr::new("asciidoc")));
+        assert!(is_spec_extension(OsStr::new("asc")));
+        assert!(!is_spec_extension(OsStr::new("rs")));
+        assert!(!is_spec_extension(OsStr::new("txt")));
+    }
+
+    #[test]
+    fn test_from_ext() {
+        assert_eq!(
+            SpecFormat::from_ext(OsStr::new("md")),
+            Some(SpecFormat::Markdown)
+        );
+        assert_eq!(
+            SpecFormat::from_ext(OsStr::new("markdown")),
+            Some(SpecFormat::Markdown)
+        );
+        assert_eq!(
+            SpecFormat::from_ext(OsStr::new("adoc")),
+            Some(SpecFormat::AsciiDoc)
+        );
+        assert_eq!(
+            SpecFormat::from_ext(OsStr::new("asciidoc")),
+            Some(SpecFormat::AsciiDoc)
+        );
+        assert_eq!(
+            SpecFormat::from_ext(OsStr::new("asc")),
+            Some(SpecFormat::AsciiDoc)
+        );
+        assert_eq!(SpecFormat::from_ext(OsStr::new("rs")), None);
+    }
+
+    #[test]
+    fn test_from_path() {
+        assert_eq!(
+            SpecFormat::from_path(Path::new("docs/spec.md")),
+            Some(SpecFormat::Markdown)
+        );
+        assert_eq!(
+            SpecFormat::from_path(Path::new("docs/spec.adoc")),
+            Some(SpecFormat::AsciiDoc)
+        );
+        assert_eq!(SpecFormat::from_path(Path::new("src/main.rs")), None);
+    }
+
+    #[test]
+    fn test_req_anchor_round_trip() {
+        let id = "auth.token.validation";
+        let anchor = req_anchor_id(id);
+        assert_eq!(anchor, "r--auth.token.validation");
+        assert_eq!(req_anchor_to_id(&anchor), Some(id));
+        assert_eq!(req_anchor_to_id("not-an-anchor"), None);
+    }
+
+    #[test]
+    fn test_slug_allocator() {
+        let mut alloc = SlugAllocator::new();
+        assert_eq!(alloc.alloc("my-heading"), "my-heading");
+        assert_eq!(alloc.alloc("my-heading"), "my-heading-2");
+        assert_eq!(alloc.alloc("my-heading"), "my-heading-3");
+        assert_eq!(alloc.alloc("other"), "other");
+    }
+
+    #[test]
+    fn test_id_range_in_marker() {
+        // r[auth.login]
+        let range = common_id_range_in_marker("r[auth.login]").unwrap();
+        assert_eq!(&"r[auth.login]"[range.clone()], "auth.login");
+
+        // r[auth.login+2]
+        let range2 = common_id_range_in_marker("r[auth.login+2]").unwrap();
+        assert_eq!(&"r[auth.login+2]"[range2.clone()], "auth.login+2");
+    }
+
+    #[test]
+    fn test_rewrite_marker() {
+        let marker = "r[auth.login]";
+        let range = common_id_range_in_marker(marker).unwrap();
+        let result = rewrite_marker(marker, range, "auth.login", 2).unwrap();
+        assert_eq!(result, "r[auth.login+2]");
+
+        let marker2 = "r[auth.login+2]";
+        let range2 = common_id_range_in_marker(marker2).unwrap();
+        let result2 = rewrite_marker(marker2, range2, "auth.login", 3).unwrap();
+        assert_eq!(result2, "r[auth.login+3]");
+    }
+}

--- a/crates/tracey/Cargo.toml
+++ b/crates/tracey/Cargo.toml
@@ -29,7 +29,7 @@ name = "tracey"
 path = "src/main.rs"
 
 [dependencies]
-tracey-core = { workspace = true, features = ["walk", "parallel", "reverse"] }
+tracey-core = { workspace = true, features = ["walk", "parallel", "reverse", "asciidoc-spec"] }
 tracey-api = { workspace = true }
 tracey-proto = { workspace = true }
 tracey-config = { workspace = true }

--- a/crates/tracey/src/daemon/service.rs
+++ b/crates/tracey/src/daemon/service.rs
@@ -168,8 +168,9 @@ fn arborium_language(path: &str) -> Option<&'static str> {
         "html" | "htm" => Some("html"),
         "css" => Some("css"),
         "scss" | "sass" => Some("scss"),
-        // Markdown
+        // Markdown / AsciiDoc
         "md" | "markdown" => Some("markdown"),
+        "adoc" | "asciidoc" | "asc" => Some("asciidoc"),
         // SQL
         "sql" => Some("sql"),
         // Zig

--- a/crates/tracey/src/data.rs
+++ b/crates/tracey/src/data.rs
@@ -28,8 +28,10 @@ use tracing::info;
 // Markdown rendering
 use marq::{
     AasvgHandler, ArboriumHandler, CompareHandler, InlineCodeHandler, MermaidHandler, PikruHandler,
-    RenderOptions, ReqHandler, parse_frontmatter, render,
+    RenderOptions, ReqHandler, render,
 };
+
+use tracey_core::spec::{SpecFormat, is_spec_extension};
 
 use crate::config::Config;
 use crate::rule_suggestions::suggest_similar_rule_ids;
@@ -316,6 +318,7 @@ fn devicon_class(path: &str) -> Option<&'static str> {
         "scss" | "sass" => Some("devicon-sass-original"),
         // Docs
         "md" | "markdown" => Some("devicon-markdown-original"),
+        "adoc" | "asciidoc" | "asc" => Some("devicon-markdown-original"),
         _ => None,
     }
 }
@@ -456,6 +459,116 @@ impl ReqHandler for TraceyRuleHandler {
             Ok("</div>\n</div>".to_string())
         })
     }
+}
+
+// ============================================================================
+// Shared badge renderer (used by both Markdown and AsciiDoc rendering)
+// ============================================================================
+
+/// Render the opening and closing HTML for a requirement container with coverage badges.
+///
+/// Returns `(open_html, close_html)` to wrap the requirement body.
+/// Used by `TraceyRuleHandler` (Markdown) and AsciiDoc `RenderCtx` alike.
+fn rule_coverage_badge_html(
+    rule: &ReqDefinition,
+    coverage: Option<&RuleCoverage>,
+    source_file: &str,
+    spec_name: &str,
+    impl_name: &str,
+) -> (String, String) {
+    let rule_id = rule.id.to_string();
+    let status = coverage.map(|c| c.status).unwrap_or("uncovered");
+    let display_id = rule_id.replace('.', ".<wbr>");
+
+    let mut badges_html = String::new();
+
+    badges_html.push_str(&format!(
+        r#"<div class="req-badge-group"><button class="req-badge req-copy req-segment-left" data-req-id="{}" title="Copy requirement ID"><svg class="req-copy-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg></button><a class="req-badge req-id req-segment-right" href="/{}/{}/spec#r--{}" data-rule="{}" data-source-file="{}" data-source-line="{}" title="{}">{}</a></div>"#,
+        &rule_id, spec_name, impl_name, &rule_id, &rule_id, source_file, rule.line, &rule_id, display_id
+    ));
+
+    if let Some(cov) = coverage {
+        if !cov.impl_refs.is_empty() {
+            let r = &cov.impl_refs[0];
+            let filename = r.file.rsplit('/').next().unwrap_or(&r.file);
+            let icon = devicon_class(&r.file)
+                .map(|c| format!(r#"<i class="{c}"></i> "#))
+                .unwrap_or_default();
+            let count_suffix = if cov.impl_refs.len() > 1 {
+                format!(" +{}", cov.impl_refs.len() - 1)
+            } else {
+                String::new()
+            };
+            let all_refs_json = cov
+                .impl_refs
+                .iter()
+                .map(|r| {
+                    format!(
+                        r#"{{"file":"{}","line":{}}}"#,
+                        r.file.replace('\\', "\\\\").replace('"', "\\\""),
+                        r.line
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+            let all_refs_json = format!("[{}]", all_refs_json).replace('"', "&quot;");
+            badges_html.push_str(&format!(
+                r#"<a class="req-badge req-impl" href="/{}/{}/sources/{}:{}" data-file="{}" data-line="{}" data-all-refs="{}" title="Implementation: {}:{}">{icon}{}:{}{}</a>"#,
+                spec_name, impl_name, r.file, r.line, r.file, r.line, all_refs_json, r.file, r.line, filename, r.line, count_suffix
+            ));
+        }
+
+        if !cov.verify_refs.is_empty() {
+            let r = &cov.verify_refs[0];
+            let filename = r.file.rsplit('/').next().unwrap_or(&r.file);
+            let icon = devicon_class(&r.file)
+                .map(|c| format!(r#"<i class="{c}"></i> "#))
+                .unwrap_or_default();
+            let count_suffix = if cov.verify_refs.len() > 1 {
+                format!(" +{}", cov.verify_refs.len() - 1)
+            } else {
+                String::new()
+            };
+            let all_refs_json = cov
+                .verify_refs
+                .iter()
+                .map(|r| {
+                    format!(
+                        r#"{{"file":"{}","line":{}}}"#,
+                        r.file.replace('\\', "\\\\").replace('"', "\\\""),
+                        r.line
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+            let all_refs_json = format!("[{}]", all_refs_json).replace('"', "&quot;");
+            badges_html.push_str(&format!(
+                r#"<a class="req-badge req-test" href="/{}/{}/sources/{}:{}" data-file="{}" data-line="{}" data-all-refs="{}" title="Test: {}:{}">{icon}{}:{}{}</a>"#,
+                spec_name, impl_name, r.file, r.line, r.file, r.line, all_refs_json, r.file, r.line, filename, r.line, count_suffix
+            ));
+        }
+    }
+
+    let edit_badge_html = format!(
+        r#"<button class="req-badge req-edit" data-br="{}-{}" data-source-file="{}" title="Edit this requirement"><svg class="req-edit-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg> Edit</button>"#,
+        rule.span.offset,
+        rule.span.offset + rule.span.length,
+        source_file
+    );
+
+    let open = format!(
+        r#"<div class="req-container req-{status}" id="{anchor}" data-br="{br_start}-{br_end}">
+<div class="req-badges-left">{badges}</div>
+<div class="req-badges-right">{edit_badge}</div>
+<div class="req-content">"#,
+        status = status,
+        anchor = rule.anchor_id,
+        br_start = rule.span.offset,
+        br_end = rule.span.offset + rule.span.length,
+        badges = badges_html,
+        edit_badge = edit_badge_html,
+    );
+    (open, "</div>\n</div>".to_string())
 }
 
 // ============================================================================
@@ -830,7 +943,9 @@ fn full_walk_for_roots(
             if !ft.is_file() {
                 continue;
             }
-            if include_markdown_only && path.extension().is_none_or(|ext| ext != "md") {
+            if include_markdown_only
+                && !path.extension().is_some_and(|ext| is_spec_extension(ext))
+            {
                 continue;
             }
             if include_supported_ext_only
@@ -864,7 +979,7 @@ fn update_cached_scan_paths(
     for changed in changed_files {
         let exists = changed.exists();
         let ext_ok = if include_markdown_only {
-            changed.extension().is_some_and(|ext| ext == "md")
+            changed.extension().is_some_and(|ext| is_spec_extension(ext))
         } else if include_supported_ext_only {
             changed.extension().is_some_and(is_supported_extension)
         } else {
@@ -998,7 +1113,9 @@ async fn extract_markdown_rules_cached(
         compute_relative_path(project_root, &canonical)
     };
 
-    let doc = render(&content, &RenderOptions::default())
+    let fmt = tracey_core::spec::SpecFormat::from_path(&canonical)
+        .unwrap_or(tracey_core::spec::SpecFormat::Markdown);
+    let doc = tracey_core::spec::parse_spec(fmt, &content)
         .await
         .map_err(|e| eyre::eyre!("Failed to process {}: {}", canonical.display(), e))?;
 
@@ -1080,7 +1197,7 @@ async fn load_rules_from_includes_cached(
         get_cached_spec_scan_paths(project_root, include_patterns, changed_files, cache);
     let (spec_roots, _) = build_scan_roots(project_root, include_patterns);
     for overlay_path in overlay.keys() {
-        if overlay_path.extension().is_none_or(|ext| ext != "md") {
+        if !overlay_path.extension().is_some_and(|ext| is_spec_extension(ext)) {
             continue;
         }
         if path_matches_any_root(overlay_path, &spec_roots) {
@@ -1971,9 +2088,10 @@ async fn compute_spec_file_diagnostics(
     for (path, content) in spec_file_contents {
         let mut diagnostics = Vec::new();
 
-        // Coverage diagnostics: parse the markdown to get requirement definitions
-        let options = RenderOptions::default();
-        if let Ok(doc) = render(content, &options).await {
+        // Coverage diagnostics: parse the spec file to get requirement definitions
+        let fmt = tracey_core::spec::SpecFormat::from_path(path)
+            .unwrap_or(tracey_core::spec::SpecFormat::Markdown);
+        if let Ok(doc) = tracey_core::spec::parse_spec(fmt, content).await {
             for def in &doc.reqs {
                 let (start_line, start_char, end_line, end_char) =
                     span_to_range(content, def.marker_span.offset, def.marker_span.length);
@@ -2470,7 +2588,8 @@ pub async fn build_dashboard_data_with_overlay_and_cache(
                 Add at least one impl block to your config:\n\n\
                 spec {{\n    \
                     name \"{}\"\n    \
-                    include \"docs/spec/**/*.md\"\n\n    \
+                    include \"docs/spec/**/*.md\"\n    \
+                    include \"docs/spec/**/*.adoc\"\n\n    \
                     impl {{\n        \
                         name \"main\"\n        \
                         include \"src/**/*.rs\"\n    \
@@ -2895,7 +3014,7 @@ async fn load_spec_content(
     for entry in walker.flatten() {
         let path = entry.path();
 
-        if path.extension().is_none_or(|ext| ext != "md") {
+        if !path.extension().is_some_and(|ext| is_spec_extension(ext)) {
             continue;
         }
 
@@ -2912,11 +3031,8 @@ async fn load_spec_content(
         }
 
         if let Ok(content) = read_file_with_overlay(path, overlay).await {
-            // Parse frontmatter to get weight
-            let weight = match parse_frontmatter(&content) {
-                Ok((fm, _)) => fm.weight,
-                Err(_) => 0, // Default weight if no frontmatter
-            };
+            let fmt = SpecFormat::from_path(path).unwrap_or(SpecFormat::Markdown);
+            let weight = tracey_core::spec::parse_weight(fmt, &content);
             files.push((relative.to_string_lossy().to_string(), content, weight));
         }
     }
@@ -2926,42 +3042,96 @@ async fn load_spec_content(
         weight_a.cmp(weight_b).then_with(|| path_a.cmp(path_b))
     });
 
-    // Concatenate all markdown files to render as one document
-    // This ensures heading IDs are hierarchical across all files
-    let mut combined_markdown = String::new();
-    let mut first_source_file = String::new();
+    let mut sections = Vec::new();
+    let mut all_elements = Vec::new();
+    let mut head_injections = Vec::new();
+    // Shared slug allocator across all formats so heading IDs stay globally unique.
+    let mut slug_alloc = tracey_core::spec::SlugAllocator::new();
 
-    for (i, (source_file, content, _weight)) in files.iter().enumerate() {
-        if i == 0 {
-            first_source_file = source_file.clone();
+    // Separate markdown files (rendered as one combined doc) from other formats.
+    let mut md_files: Vec<(String, String, i32)> = Vec::new();
+    let mut other_files: Vec<(String, String, i32)> = Vec::new();
+    for file in files {
+        let ext = file.0.rsplit('.').next().unwrap_or("").to_lowercase();
+        if ext == "md" || ext == "markdown" {
+            md_files.push(file);
+        } else {
+            other_files.push(file);
         }
-        combined_markdown.push_str(content);
-        combined_markdown.push_str("\n\n"); // Ensure separation between files
     }
 
-    // Render the combined document once (so heading_stack works across files)
-    // Set source_path so paragraphs get data-source-file attributes for click-to-edit
-    // Must use absolute path for editor navigation to work correctly
-    *current_source_file.lock().unwrap() = first_source_file.clone();
-    let absolute_source_path = root.join(&first_source_file).display().to_string();
-    let opts = opts.with_source_path(&absolute_source_path);
-    let doc = render(&combined_markdown, &opts).await?;
+    // Render all markdown files concatenated (preserves cross-file heading hierarchy).
+    if !md_files.is_empty() {
+        let mut combined_markdown = String::new();
+        let first_source_file = md_files[0].0.clone();
 
-    // Create a single section with all content
-    // (Frontend concatenates sections anyway, this just simplifies tracking)
-    let mut sections = Vec::new();
-    if !files.is_empty() {
+        for (_, content, _) in &md_files {
+            combined_markdown.push_str(content);
+            combined_markdown.push_str("\n\n");
+        }
+
+        *current_source_file.lock().unwrap() = first_source_file.clone();
+        let absolute_source_path = root.join(&first_source_file).display().to_string();
+        let md_opts = opts.with_source_path(&absolute_source_path);
+        let doc = render(&combined_markdown, &md_opts).await?;
+
         sections.push(SpecSection {
             source_file: first_source_file,
             html: doc.html,
-            weight: files[0].2,
+            weight: md_files[0].2,
         });
+        all_elements.extend(doc.elements);
+        head_injections.extend(doc.head_injections);
     }
 
-    let all_elements = doc.elements;
-    let head_injections = doc.head_injections;
+    // Render each non-Markdown spec file independently.
+    for (source_file, content, weight) in &other_files {
+        let abs_path = root.join(source_file);
+        let fmt = tracey_core::spec::SpecFormat::from_path(&abs_path)
+            .unwrap_or(tracey_core::spec::SpecFormat::AsciiDoc);
+        let abs_source_str = abs_path.display().to_string();
 
-    // Build outline from elements
+        match fmt {
+            tracey_core::spec::SpecFormat::AsciiDoc => {
+                let ctx = tracey_core::spec::asciidoc::RenderCtx {
+                    badge_for: &|def: &ReqDefinition| {
+                        rule_coverage_badge_html(
+                            def,
+                            coverage.get(&def.id.to_string()),
+                            &abs_source_str,
+                            spec_name,
+                            impl_name,
+                        )
+                    },
+                };
+                let mut deps = std::collections::HashSet::new();
+                let doc = tracey_core::spec::asciidoc::render_display(
+                    content,
+                    &abs_path,
+                    &ctx,
+                    &mut slug_alloc,
+                    &mut deps,
+                )
+                .await?;
+                sections.push(SpecSection {
+                    source_file: source_file.clone(),
+                    html: doc.html,
+                    weight: *weight,
+                });
+                all_elements.extend(doc.elements);
+                head_injections.extend(doc.head_injections);
+            }
+            _ => {
+                // Unknown format — skip with a warning
+                eprintln!(
+                    "load_spec_content: rendering not implemented for spec format {:?}, skipping {}",
+                    fmt, source_file
+                );
+            }
+        }
+    }
+
+    // Build outline from all elements
     let outline = build_outline(&all_elements, coverage);
 
     if !sections.is_empty() {

--- a/crates/tracey/src/lib.rs
+++ b/crates/tracey/src/lib.rs
@@ -17,9 +17,8 @@ use config::Config;
 use eyre::{Result, WrapErr};
 use std::path::PathBuf;
 use tracey_core::ReqDefinition;
+use tracey_core::spec::{SpecFormat, is_spec_extension, parse_spec};
 
-// Re-export from marq for rule extraction
-use marq::{RenderOptions, render};
 
 /// Extracted rule with source location info
 #[derive(Clone)]
@@ -125,8 +124,8 @@ pub async fn load_rules_from_glob(
         let entry = entry?;
         let path = entry.path();
 
-        // Only process .md files
-        if path.extension().is_none_or(|ext| ext != "md") {
+        // Only process spec files (.md, .adoc, etc.)
+        if !path.extension().is_some_and(|ext| is_spec_extension(ext)) {
             continue;
         }
 
@@ -148,11 +147,13 @@ pub async fn load_rules_from_glob(
             continue;
         }
 
-        // Read and render markdown to extract rules with HTML
+        // Read and parse the spec file to extract requirements
         let content = std::fs::read_to_string(path)
             .wrap_err_with(|| format!("Failed to read {}", path.display()))?;
 
-        let doc = render(&content, &RenderOptions::default())
+        let fmt = SpecFormat::from_path(path)
+            .unwrap_or(SpecFormat::Markdown);
+        let doc = parse_spec(fmt, &content)
             .await
             .map_err(|e| eyre::eyre!("Failed to process {}: {}", path.display(), e))?;
 
@@ -169,6 +170,7 @@ pub async fn load_rules_from_glob(
             // Check for duplicates
             // r[impl markdown.duplicates.same-file] - caught when marq returns duplicate reqs from single file
             // r[impl markdown.duplicates.cross-file] - caught via seen_ids persisting across files
+            // r[impl asciidoc.duplicates.cross-file] - same mechanism applies to .adoc files
             for req in &doc.reqs {
                 let req_id = req.id.to_string();
                 if seen_ids.contains(&req_id) {

--- a/crates/tracey/tests/asciidoc_spec_tests.rs
+++ b/crates/tracey/tests/asciidoc_spec_tests.rs
@@ -1,0 +1,382 @@
+//! Integration tests for AsciiDoc spec file support.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tracey_core::parse_rule_id;
+
+mod common;
+
+fn rpc<T, E: std::fmt::Debug>(res: Result<T, roam::RoamError<E>>) -> T {
+    res.expect("RPC call failed")
+}
+
+fn rid(id: &str) -> tracey_core::RuleId {
+    parse_rule_id(id).expect("valid rule id")
+}
+
+fn fixtures_asciidoc() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures-asciidoc")
+}
+
+async fn create_adoc_engine() -> Arc<tracey::daemon::Engine> {
+    let project_root = fixtures_asciidoc();
+    let config_path = project_root.join("config.styx");
+    Arc::new(
+        tracey::daemon::Engine::new(project_root, config_path)
+            .await
+            .expect("Failed to create AsciiDoc test engine"),
+    )
+}
+
+async fn create_adoc_service() -> common::RpcTestService {
+    let engine = create_adoc_engine().await;
+    let service = tracey::daemon::TraceyService::new(engine);
+    common::create_test_rpc_service(service).await
+}
+
+// ============================================================================
+// Parsing: spec file discovery and rule extraction
+// ============================================================================
+
+#[tokio::test]
+async fn test_adoc_status_has_rules() {
+    let service = create_adoc_service().await;
+    let status = rpc(service.client.status().await);
+
+    let test_impl = status
+        .impls
+        .iter()
+        .find(|i| i.spec == "test" && i.impl_name == "rust")
+        .expect("test/rust impl should exist");
+
+    assert!(
+        test_impl.total_rules >= 7,
+        "Expected at least 7 rules from spec.adoc, got {}",
+        test_impl.total_rules
+    );
+}
+
+#[tokio::test]
+async fn test_adoc_listing_block_masks_markers() {
+    let service = create_adoc_service().await;
+    let status = rpc(service.client.status().await);
+
+    let test_impl = status
+        .impls
+        .iter()
+        .find(|i| i.spec == "test" && i.impl_name == "rust")
+        .expect("test/rust impl should exist");
+
+    // The masked markers inside listing/comment blocks must not appear as rules
+    assert!(
+        test_impl.total_rules < 15,
+        "Listing/comment block masking failed — too many rules: {}",
+        test_impl.total_rules
+    );
+}
+
+#[tokio::test]
+async fn test_adoc_rule_lookup() {
+    let service = create_adoc_service().await;
+    let rule = rpc(service.client.rule(rid("auth.login")).await);
+
+    assert!(rule.is_some(), "auth.login rule should exist");
+    let info = rule.unwrap();
+    assert_eq!(info.id, rid("auth.login"));
+    assert!(
+        info.raw.contains("valid credentials"),
+        "Rule body should contain spec text, got: {:?}",
+        info.raw
+    );
+}
+
+#[tokio::test]
+async fn test_adoc_anchor_ids_use_r_prefix() {
+    // Parse the spec directly to check anchor IDs
+    use tracey_core::spec::{SpecFormat, parse_spec};
+
+    let spec_path = fixtures_asciidoc().join("spec.adoc");
+    let content = std::fs::read_to_string(&spec_path).expect("read spec.adoc");
+    let doc = parse_spec(SpecFormat::AsciiDoc, &content)
+        .await
+        .expect("parse AsciiDoc spec");
+
+    for req in &doc.reqs {
+        assert!(
+            req.anchor_id.starts_with("r--"),
+            "anchor_id {:?} does not start with 'r--'",
+            req.anchor_id
+        );
+        assert_eq!(
+            req.anchor_id,
+            format!("r--{}", req.id),
+            "anchor_id mismatch for {}",
+            req.id
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_adoc_parse_extracts_headings() {
+    use tracey_core::spec::{SpecFormat, parse_spec};
+
+    let spec_path = fixtures_asciidoc().join("spec.adoc");
+    let content = std::fs::read_to_string(&spec_path).expect("read spec.adoc");
+    let doc = parse_spec(SpecFormat::AsciiDoc, &content)
+        .await
+        .expect("parse AsciiDoc spec");
+
+    assert!(
+        !doc.headings.is_empty(),
+        "Expected headings to be extracted"
+    );
+    let titles: Vec<_> = doc.headings.iter().map(|h| h.title.as_str()).collect();
+    assert!(
+        titles.contains(&"Authentication"),
+        "Expected 'Authentication' heading, got: {:?}",
+        titles
+    );
+}
+
+#[tokio::test]
+async fn test_adoc_parse_reqs_have_correct_line_numbers() {
+    use tracey_core::spec::{SpecFormat, parse_spec};
+
+    let spec_path = fixtures_asciidoc().join("spec.adoc");
+    let content = std::fs::read_to_string(&spec_path).expect("read spec.adoc");
+    let doc = parse_spec(SpecFormat::AsciiDoc, &content)
+        .await
+        .expect("parse AsciiDoc spec");
+
+    let auth_login = doc
+        .reqs
+        .iter()
+        .find(|r| r.id.to_string() == "auth.login")
+        .expect("auth.login should be present");
+
+    assert!(
+        auth_login.line > 0,
+        "line number should be positive, got {}",
+        auth_login.line
+    );
+}
+
+// ============================================================================
+// Coverage: uncovered / untested rules
+// ============================================================================
+
+#[tokio::test]
+async fn test_adoc_uncovered_rules() {
+    let service = create_adoc_service().await;
+    let status = rpc(service.client.status().await);
+
+    let test_impl = status
+        .impls
+        .iter()
+        .find(|i| i.spec == "test" && i.impl_name == "rust")
+        .expect("test/rust impl should exist");
+
+    // Covered rules should not exceed total
+    assert!(
+        test_impl.covered_rules <= test_impl.total_rules,
+        "covered ({}) > total ({})",
+        test_impl.covered_rules,
+        test_impl.total_rules
+    );
+}
+
+// ============================================================================
+// Bump: id_range_in_marker and rewrite_marker work for .adoc files
+// ============================================================================
+
+#[test]
+fn test_adoc_id_range_in_marker() {
+    use tracey_core::spec::{SpecFormat, id_range_in_marker};
+
+    let marker = "r[auth.login]";
+    let range = id_range_in_marker(SpecFormat::AsciiDoc, marker).expect("id_range");
+    assert_eq!(&marker[range], "auth.login");
+}
+
+#[test]
+fn test_adoc_rewrite_marker() {
+    use tracey_core::spec::{SpecFormat, id_range_in_marker, rewrite_marker};
+
+    let marker = "r[auth.login]";
+    let range = id_range_in_marker(SpecFormat::AsciiDoc, marker).expect("id_range");
+    let rewritten = rewrite_marker(marker, range, "auth.login", 2).expect("rewrite");
+    assert_eq!(rewritten, "r[auth.login+2]");
+}
+
+#[test]
+fn test_adoc_extract_marker_prefix() {
+    use tracey_core::spec::{SpecFormat, SourceSpan, extract_marker_prefix};
+
+    let content = "r[auth.login] Some text";
+    let span = SourceSpan { offset: 0, length: 13 }; // covers "r[auth.login]"
+    let prefix =
+        extract_marker_prefix(SpecFormat::AsciiDoc, content, span).expect("prefix");
+    assert_eq!(prefix, "r");
+}
+
+// ============================================================================
+// parse_weight for AsciiDoc attribute syntax
+// ============================================================================
+
+#[test]
+fn test_adoc_parse_weight_attribute() {
+    use tracey_core::spec::{SpecFormat, parse_weight};
+
+    assert_eq!(parse_weight(SpecFormat::AsciiDoc, ":weight: 10\n\n= Title"), 10);
+    assert_eq!(parse_weight(SpecFormat::AsciiDoc, "= Title\n\nNo weight"), 0);
+}
+
+#[test]
+fn test_adoc_parse_weight_frontmatter() {
+    use tracey_core::spec::{SpecFormat, parse_weight};
+
+    assert_eq!(
+        parse_weight(SpecFormat::AsciiDoc, "---\nweight: 5\n---\n\n= Title"),
+        5
+    );
+}
+
+// ============================================================================
+// New capabilities: tables, admonitions, inline formatting
+// ============================================================================
+
+#[tokio::test]
+async fn test_adoc_table_renders_in_html() {
+    use tracey_core::spec::{SpecFormat, parse_spec};
+
+    let src = "= Doc\n\n|===\n|A |B\n\n|1 |2\n|===\n";
+    let doc = parse_spec(SpecFormat::AsciiDoc, src).await.expect("parse");
+    assert!(
+        doc.html.contains("<table"),
+        "table should render to HTML, got: {}",
+        &doc.html[..doc.html.len().min(400)]
+    );
+    assert!(doc.reqs.is_empty(), "table block should not produce requirements");
+}
+
+#[tokio::test]
+async fn test_adoc_fixture_has_table_reqs() {
+    use tracey_core::spec::{SpecFormat, parse_spec};
+
+    let spec_path = fixtures_asciidoc().join("spec.adoc");
+    let content = std::fs::read_to_string(&spec_path).expect("read spec.adoc");
+    let doc = parse_spec(SpecFormat::AsciiDoc, &content).await.expect("parse");
+
+    let ids: Vec<_> = doc.reqs.iter().map(|r| r.id.to_string()).collect();
+    assert!(ids.contains(&"table.structure".to_string()), "table.structure should be present, got: {:?}", ids);
+    assert!(ids.contains(&"table.inline-code".to_string()), "table.inline-code should be present");
+    assert!(ids.contains(&"format.bold".to_string()), "format.bold should be present");
+    assert!(ids.contains(&"format.multiline".to_string()), "format.multiline should be present");
+}
+
+#[tokio::test]
+async fn test_adoc_table_html_in_fixture() {
+    use tracey_core::spec::{SpecFormat, parse_spec};
+
+    let spec_path = fixtures_asciidoc().join("spec.adoc");
+    let content = std::fs::read_to_string(&spec_path).expect("read spec.adoc");
+    let doc = parse_spec(SpecFormat::AsciiDoc, &content).await.expect("parse");
+
+    assert!(
+        doc.html.contains("<table"),
+        "fixture HTML should contain a rendered table"
+    );
+}
+
+#[tokio::test]
+async fn test_adoc_multiline_req_raw() {
+    use tracey_core::spec::{SpecFormat, parse_spec};
+
+    let src = "r[multi.line]\nFirst sentence.\nSecond sentence.\n";
+    let doc = parse_spec(SpecFormat::AsciiDoc, src).await.expect("parse");
+
+    let req = doc.reqs.iter().find(|r| r.id.to_string() == "multi.line").expect("multi.line");
+    assert!(
+        req.raw.contains("First sentence."),
+        "raw should contain first line, got: {:?}",
+        req.raw
+    );
+    assert!(
+        req.raw.contains("Second sentence."),
+        "raw should contain second line, got: {:?}",
+        req.raw
+    );
+}
+
+#[tokio::test]
+async fn test_adoc_req_html_injected_in_spec_html() {
+    use tracey_core::spec::{SpecFormat, parse_spec};
+
+    let src = "r[inject.test]\nThis requirement should be wrapped.\n";
+    let doc = parse_spec(SpecFormat::AsciiDoc, src).await.expect("parse");
+
+    assert!(
+        doc.html.contains("r--inject.test"),
+        "spec HTML should contain req anchor id, got: {}",
+        &doc.html[..doc.html.len().min(500)]
+    );
+    assert!(
+        doc.html.contains("req-container"),
+        "spec HTML should contain req-container div"
+    );
+}
+
+#[tokio::test]
+async fn test_adoc_inline_ignored_not_a_req() {
+    use tracey_core::spec::{SpecFormat, parse_spec};
+
+    let src = "See r[auth.login] for details.\n";
+    let doc = parse_spec(SpecFormat::AsciiDoc, src).await.expect("parse");
+    assert!(doc.reqs.is_empty(), "inline marker should not be a requirement");
+}
+
+#[tokio::test]
+async fn test_adoc_duplicate_req_errors() {
+    use tracey_core::spec::{SpecFormat, parse_spec};
+
+    let src = "r[dup.id]\nFirst.\n\nr[dup.id]\nSecond.\n";
+    let result = parse_spec(SpecFormat::AsciiDoc, src).await;
+    assert!(result.is_err(), "duplicate requirement should return an error");
+}
+
+#[tokio::test]
+async fn test_adoc_cross_file_xref_does_not_error() {
+    use tracey_core::spec::{SpecFormat, parse_spec};
+
+    // Cross-file xrefs (<<anchor-in-another-file>>) are unresolvable during
+    // per-file parsing but valid at display time since all spec files share
+    // one HTML page. The parser must not return an error for these.
+    let src = "== Section A\n\nSee <<other-section>> for details.\n";
+    let doc = parse_spec(SpecFormat::AsciiDoc, src).await
+        .expect("cross-file xref should not cause a parse error");
+    assert!(
+        doc.html.contains("other-section"),
+        "HTML should contain the xref target as a link, got: {}",
+        &doc.html[..doc.html.len().min(500)]
+    );
+}
+
+#[tokio::test]
+async fn test_adoc_heading_ids_in_html_match_headings() {
+    use tracey_core::spec::{SpecFormat, parse_spec};
+
+    let src = "== My Section\n\nSome text.\n";
+    let doc = parse_spec(SpecFormat::AsciiDoc, src).await.expect("parse");
+
+    assert!(!doc.headings.is_empty(), "should have at least one heading");
+    let heading = &doc.headings[0];
+    assert!(
+        doc.html.contains(&format!("id=\"{}\"", heading.id)),
+        "HTML should contain heading id {:?}, got html: {}",
+        heading.id,
+        &doc.html[..doc.html.len().min(500)]
+    );
+}

--- a/crates/tracey/tests/fixtures-asciidoc/config.styx
+++ b/crates/tracey/tests/fixtures-asciidoc/config.styx
@@ -1,0 +1,15 @@
+// Tracey configuration for AsciiDoc integration tests
+
+specs (
+  {
+    name test
+    include (spec.adoc)
+    impls (
+      {
+        name rust
+        include (src/**/*.rs)
+        test_include (src/tests.rs)
+      }
+    )
+  }
+)

--- a/crates/tracey/tests/fixtures-asciidoc/spec.adoc
+++ b/crates/tracey/tests/fixtures-asciidoc/spec.adoc
@@ -1,0 +1,74 @@
+= Test AsciiDoc Specification
+
+This is a test AsciiDoc specification for integration testing.
+
+== Authentication
+
+r[auth.login]
+Users MUST provide valid credentials to log in.
+
+r[auth.session]
+Sessions MUST expire after 24 hours of inactivity.
+
+r[auth.logout]
+Users MUST be able to log out and invalidate their session.
+
+== Data Validation
+
+r[data.required-fields]
+All required fields MUST be validated before processing.
+
+r[data.format]
+Email addresses MUST be validated against RFC 5322 format.
+
+== Error Handling
+
+r[error.codes]
+All errors MUST include a machine-readable error code.
+
+r[error.messages]
+Error messages MUST be human-readable and actionable.
+
+== Masking Examples
+
+The following listing block MUST NOT produce a requirement:
+
+----
+r[masked.example]
+This marker is inside a listing block and must be ignored.
+----
+
+// r[masked.line-comment] This line comment marker must also be ignored.
+
+////
+r[masked.block-comment]
+This block comment marker must be ignored.
+////
+
+== Tables and Formatting
+
+r[table.structure]
+The system MUST provide a structured comparison table of features.
+
+|===
+|Feature |Required |Notes
+
+|Authentication |Yes |Multi-factor support
+|Audit Logging |Yes |Tamper-proof storage
+|Rate Limiting |No |Optional for v1
+|===
+
+NOTE: This admonition block MUST render correctly without producing a requirement.
+
+r[table.inline-code]
+All API endpoints MUST be documented with their `method` and `path`.
+
+== Inline Formatting
+
+r[format.bold]
+Critical requirements MUST be marked as *mandatory* in the specification.
+
+r[format.multiline]
+This requirement spans multiple lines.
+The second line continues the requirement body.
+The third line adds further context.

--- a/crates/tracey/tests/fixtures-asciidoc/src/lib.rs
+++ b/crates/tracey/tests/fixtures-asciidoc/src/lib.rs
@@ -1,0 +1,65 @@
+//! Test implementation for AsciiDoc integration testing.
+
+/// Login function
+///
+/// r[impl auth.login]
+pub fn login(username: &str, password: &str) -> Result<Session, Error> {
+    if username.is_empty() || password.is_empty() {
+        return Err(Error::InvalidCredentials);
+    }
+    Ok(Session { id: 1 })
+}
+
+/// Session struct
+///
+/// r[impl auth.session]
+pub struct Session {
+    pub id: u64,
+}
+
+/// Logout function
+///
+/// r[impl auth.logout]
+pub fn logout(_session: Session) {}
+
+/// Validate required fields
+///
+/// r[impl data.required-fields]
+/// r[impl error.codes]
+/// r[impl error.messages]
+pub fn validate_required(data: &[(&str, Option<&str>)]) -> Result<(), Error> {
+    for (name, value) in data {
+        if value.is_none() {
+            return Err(Error::MissingField(name.to_string()));
+        }
+    }
+    Ok(())
+}
+
+/// Error type
+///
+/// r[impl error.codes]
+#[derive(Debug)]
+pub enum Error {
+    InvalidCredentials,
+    MissingField(String),
+    InvalidFormat(String),
+}
+
+impl std::fmt::Display for Error {
+    /// r[impl error.messages]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::InvalidCredentials => write!(f, "Invalid username or password"),
+            Error::MissingField(field) => write!(f, "Missing required field: {}", field),
+            Error::InvalidFormat(msg) => write!(f, "Invalid format: {}", msg),
+        }
+    }
+}
+
+/// Validate email format
+///
+/// r[impl data.format]
+pub fn validate_email(email: &str) -> bool {
+    email.contains('@') && email.contains('.')
+}

--- a/crates/tracey/tests/fixtures-asciidoc/src/tests.rs
+++ b/crates/tracey/tests/fixtures-asciidoc/src/tests.rs
@@ -1,0 +1,9 @@
+//! Test file for AsciiDoc integration testing.
+
+/// r[verify auth.login]
+#[test]
+fn test_login() {}
+
+/// r[verify auth.session]
+#[test]
+fn test_session() {}

--- a/crates/tracey/tests/watcher_tests.rs
+++ b/crates/tracey/tests/watcher_tests.rs
@@ -256,6 +256,36 @@ async fn test_engine_rebuild_increments_version() {
 // Helper: create a temp project for engine rebuild tests
 // ============================================================================
 
+/// Create a temporary project with an AsciiDoc spec, config, and source file.
+/// Returns (temp_dir, config_path) — temp_dir must be kept alive for the test duration.
+fn create_rebuild_test_project_adoc(
+    spec_content: &str,
+    source_files: &[(&str, &str)],
+) -> (tempfile::TempDir, std::path::PathBuf) {
+    let temp = tempfile::tempdir().expect("Failed to create temp dir");
+    let root = temp.path();
+
+    std::fs::create_dir_all(root.join(".config/tracey")).expect("create config dir");
+    let config_path = root.join(".config/tracey/config.styx");
+    std::fs::write(
+        &config_path,
+        "specs (\n  {\n    name test\n    include (spec.adoc)\n    impls (\n      {\n        name rust\n        include (src/**/*.rs)\n      }\n    )\n  }\n)\n",
+    )
+    .expect("write config");
+
+    std::fs::write(root.join("spec.adoc"), spec_content).expect("write spec");
+    std::fs::create_dir_all(root.join("src")).expect("create src dir");
+    for (name, content) in source_files {
+        let path = root.join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent dir");
+        }
+        std::fs::write(&path, content).expect("write source file");
+    }
+
+    (temp, config_path)
+}
+
 /// Create a temporary project with a config, spec, and source file.
 /// Returns (temp_dir, config_path) — temp_dir must be kept alive for the test duration.
 fn create_rebuild_test_project(
@@ -525,5 +555,54 @@ async fn test_rebuild_modify_source_file() {
     assert!(
         rule_has_impl_refs(&data, "auth.login"),
         "Expected auth.login to have impl refs after modifying source"
+    );
+}
+
+/// Editing an AsciiDoc spec file triggers a rebuild and the new rule is picked up.
+#[tokio::test]
+async fn test_rebuild_adoc_spec_file_change() {
+    use tracey::daemon::Engine;
+
+    let (temp, config_path) = create_rebuild_test_project_adoc(
+        "= Spec\n\nr[auth.login]\nUsers must log in.\n",
+        &[("src/lib.rs", "/// r[impl auth.login]\npub fn login() {}\n")],
+    );
+    let root = temp.path().to_path_buf();
+
+    let engine = Arc::new(
+        Engine::new(root.clone(), config_path)
+            .await
+            .expect("Failed to create engine"),
+    );
+
+    let version1 = engine.version();
+
+    // Add a new rule to the adoc spec
+    let spec_path = root.join("spec.adoc");
+    std::fs::write(
+        &spec_path,
+        "= Spec\n\nr[auth.login]\nUsers must log in.\n\nr[auth.logout]\nUsers must log out.\n",
+    )
+    .expect("update spec.adoc");
+
+    engine
+        .rebuild_with_changes(&[spec_path])
+        .await
+        .expect("rebuild failed");
+
+    let version2 = engine.version();
+    assert!(
+        version2 > version1,
+        "Version should increment after adoc spec change"
+    );
+
+    let data = engine.data().await;
+    assert!(
+        has_rule_in_forward(&data, "auth.logout"),
+        "Expected auth.logout in forward data after updating adoc spec"
+    );
+    assert!(
+        rule_has_impl_refs(&data, "auth.login"),
+        "auth.login should still be covered after adoc spec change"
     );
 }

--- a/docs/content/guide/getting-started.md
+++ b/docs/content/guide/getting-started.md
@@ -32,7 +32,7 @@ This registers tracey as an MCP server and installs the bundled Tracey skill.
 
 ## Create your spec
 
-Create a markdown file with your requirements. Each requirement uses the syntax `r[requirement.id]` followed by its text:
+Create a spec file with your requirements. Tracey supports Markdown (`.md`) and AsciiDoc (`.adoc`) files. Each requirement uses the syntax `r[requirement.id]` followed by its text:
 
 ```markdown
 <!-- docs/spec/api.md -->

--- a/docs/content/guide/writing-specs.md
+++ b/docs/content/guide/writing-specs.md
@@ -3,7 +3,7 @@ title = "Writing Specs"
 weight = 2
 +++
 
-Specifications are markdown documents containing requirements. Each requirement has a unique ID and describes a single behavior or constraint that is both implementable and testable.
+Specifications are documents containing requirements. Tracey supports Markdown (`.md`) and AsciiDoc (`.adoc`, `.asciidoc`) spec files. Each requirement has a unique ID and describes a single behavior or constraint that is both implementable and testable.
 
 ## Requirement markers
 
@@ -152,6 +152,39 @@ Messages must use Protocol Buffers.
 ```
 
 These don't conflict because `r[api.format]` and `m[api.format]` belong to different specs.
+
+## AsciiDoc specs
+
+Tracey also supports AsciiDoc (`.adoc`, `.asciidoc`, `.asc`) spec files. The requirement marker syntax is identical to Markdown — markers at column 0 define requirements:
+
+```adoc
+r[auth.login]
+The system must accept a username and password and return a session token.
+```
+
+Use a `____` quote block for multi-paragraph requirements (the AsciiDoc equivalent of a Markdown blockquote):
+
+```adoc
+____
+r[api.error-format]
+API errors must follow this format:
+
+[source,json]
+----
+{"error": "message", "code": 400}
+----
+____
+```
+
+Markers inside listing blocks (`----`), literal blocks (`....`), passthrough blocks (`++++`), and comments (`//`, `////`) are masked and not treated as requirement definitions.
+
+Configure AsciiDoc spec files the same way as Markdown in your `config.styx`:
+
+```styx
+include (docs/spec/**/*.adoc)
+```
+
+You can mix Markdown and AsciiDoc files in the same spec — each file is parsed independently and their requirements are merged.
 
 ## Versioning
 

--- a/docs/content/spec/tracey.md
+++ b/docs/content/spec/tracey.md
@@ -121,6 +121,86 @@ Requirements are defined in markdown specification documents using the syntax `P
 > OK - different spec, different prefix, no conflict.
 > ```
 
+## Requirement Definitions in AsciiDoc
+
+AsciiDoc (`.adoc`, `.asciidoc`, `.asc`) files are supported as a second spec format. The requirement marker syntax is identical to Markdown.
+
+### AsciiDoc Requirement Syntax
+
+> r[asciidoc.syntax.marker]
+> A requirement definition in AsciiDoc MUST be written as `PREFIX[REQ]` in one of two contexts: as a standalone paragraph at column 0, or as the first line inside an AsciiDoc `____` quote block. The PREFIX and REQ follow the same rules as in Markdown.
+>
+> Valid (standalone paragraph):
+> ```adoc
+> r[auth.token.validation]
+> The system must validate tokens before granting access.
+> ```
+>
+> Valid (quote block for multi-paragraph content):
+> ```adoc
+> ____
+> r[api.error.format]
+> API errors must follow this format:
+>
+> [source,json]
+> ----
+> {"error": "message", "code": 400}
+> ----
+> ____
+> ```
+
+> r[asciidoc.syntax.inline-ignored]
+> Requirement markers that appear inline within other text MUST be treated as regular text, not requirement definitions.
+>
+> Invalid (treated as text, not a definition):
+> ```adoc
+> When implementing r[database.connection] you should...
+> ```
+
+### Duplicate Detection
+
+> r[asciidoc.duplicates.same-file]
+> If the same requirement ID appears multiple times in a single AsciiDoc file, an error MUST be reported.
+
+> r[asciidoc.duplicates.cross-file]
+> If the same requirement ID appears in multiple AsciiDoc files (or across AsciiDoc and Markdown files) within the same spec, an error MUST be reported when merging manifests.
+
+### Block Masking
+
+> r[asciidoc.blocks.listing]
+> Requirement markers that appear inside listing blocks (`----`), literal blocks (`....`), passthrough blocks (`++++`), line comments (`//`), or block comments (`////`) MUST be ignored — they do not define requirements.
+>
+> ```adoc
+> ----
+> r[masked.example]
+> This is inside a listing block — not a requirement.
+> ----
+>
+> // r[also.masked] This line comment marker is also ignored.
+> ```
+
+### Frontmatter and Weight
+
+> r[asciidoc.frontmatter.attributes]
+> The sort weight for an AsciiDoc spec file MUST be read from a `:weight: N` document attribute near the top of the file. YAML/TOML frontmatter (`---`/`+++` delimiters) is also accepted for compatibility.
+>
+> ```adoc
+> :weight: 10
+>
+> = My Spec
+> ```
+
+### HTML Output
+
+> r[asciidoc.html.div]
+> Each requirement in a rendered AsciiDoc spec MUST be wrapped in a `<div>` container element with CSS classes indicating coverage status.
+
+> r[asciidoc.html.anchor]
+> The requirement container `<div>` MUST carry an `id` attribute of the form `r--{req.id}` so requirement anchors are linkable in the rendered output.
+
+> r[asciidoc.html.link]
+> When rendered with coverage context, each requirement container MUST include a coverage badge that links to the implementing code.
+
 ## Requirement References in Source Code
 
 Requirement references are extracted from source code comments using the syntax `PREFIX[VERB REQ]` where PREFIX matches a spec marker inferred from requirement definitions.

--- a/unhand-spec.md
+++ b/unhand-spec.md
@@ -1,0 +1,417 @@
+# Plan: Replace Hand-Rolled AsciiDoc Parser with `asciidork-parser`
+
+Replace the 921-line hand-rolled parser in `crates/tracey-core/src/spec/asciidoc.rs` with
+`asciidork-parser` + `asciidork-dr-html-backend`. The public API surface of `asciidoc.rs`
+does not change; the refactor is entirely internal to that file.
+
+The goal is to reach the same relationship that Markdown has with `marq`/`pulldown-cmark`:
+a thin adapter layer over a well-maintained external parser, rather than a bespoke
+line-scanner that must be kept in sync with the AsciiDoc spec by hand.
+
+---
+
+## 1. Current architecture
+
+```
+asciidoc.rs (hand-rolled, 921 lines)
+  parse()          — line-by-line scanner → marq::Document
+  render_display() — same scanner, badge injection via RenderCtx closure
+  parse_weight()   — scans :weight: attribute + YAML/TOML frontmatter
+  diff_inline()    — delegates to marq::diff_markdown_inline (unchanged)
+  extract_marker_prefix() / id_range_in_marker() — shared helpers (unchanged)
+```
+
+What the scanner handles today: headings, paragraphs, quote blocks (`____`), listing
+(`----`), literal (`....`), passthrough (`++++`), line comments (`//`), block comments
+(`////`), document attributes, YAML/TOML frontmatter, inline backtick spans.
+
+What it does **not** handle: tables, admonitions, callouts, definition lists, ordered lists,
+nested blocks, includes, conditionals, STEM, source highlighting, most inline formatting.
+
+---
+
+## 2. Target architecture
+
+```
+asciidoc.rs (thin adapter, ~200 lines)
+  parse()          — asciidork-parser AST → walk → marq::Document  (cheap path)
+  render_display() — asciidork-parser AST → TraceyAdocBackend → marq::Document
+  parse_weight()   — read from asciidork AST document header attributes
+  diff_inline()    — unchanged (delegates to marq)
+  extract_marker_prefix() / id_range_in_marker() — unchanged (shared helpers)
+
+asciidoc/backend.rs (new)
+  TraceyAdocBackend — wraps asciidork-dr-html-backend, intercepts requirement
+                      paragraphs/quote-blocks to inject <div> wrappers and badges
+```
+
+The `marq::Document` type (aliased as `SpecDoc` in `spec/mod.rs`) is unchanged — it
+remains the shared output type for all formats, populated from the asciidork AST walk.
+
+---
+
+## 3. Dependency changes
+
+### `crates/tracey-core/Cargo.toml`
+
+Add to `[dependencies]`:
+
+```toml
+asciidork-parser  = { version = "0.38", optional = true }
+asciidork-ast     = { version = "0.38", optional = true }
+asciidork-backend = { version = "0.38", optional = true }
+asciidork-dr-html-backend = { version = "0.38", optional = true }
+```
+
+Add a Cargo feature (mirroring the precedent for future heavy renderers):
+
+```toml
+[features]
+asciidoc-spec = [
+    "dep:asciidork-parser",
+    "dep:asciidork-ast",
+    "dep:asciidork-backend",
+    "dep:asciidork-dr-html-backend",
+]
+```
+
+Enable it by default in the binary:
+
+```toml
+# crates/tracey/Cargo.toml
+tracey-core = { ..., features = ["asciidoc-spec"] }
+```
+
+**Note:** Verify whether `asciidork-parser` is `no_std`-compatible or requires `std`.
+If bumpalo arena types appear in the public API (they do — the Parser and AST nodes are
+arena-allocated), the library consumer must bring in `bumpalo` transitively. This is
+handled automatically via Cargo's dependency resolution.
+
+---
+
+## 4. Understanding where requirement markers appear in the asciidork AST
+
+Before writing the adapter, confirm the AST shapes for the two marker syntaxes:
+
+**Paragraph form:**
+```adoc
+r[auth.login]
+The system must validate tokens.
+```
+Expected asciidork AST: a `Block::Paragraph` whose first `InlineNode` is a text node
+whose content starts with `r[auth.login]`.
+
+**Quote-block form:**
+```adoc
+____
+r[auth.login]
+The system must validate tokens.
+____
+```
+Expected asciidork AST: a `Block::Quote` (or similar delimited block) containing a
+`Block::Paragraph` with the same leading marker.
+
+**Verify this in commit 1** by writing a small test that prints the AST of each form
+before writing any extraction logic. The exact type names (`Block`, `InlineNode`,
+`InlineContent`, etc.) are in `asciidork-ast` — consult its docs at
+`https://docs.rs/asciidork-ast`.
+
+---
+
+## 5. Implementation plan (4 commits)
+
+### Commit 1 — Wire dependencies, add AST shape tests
+
+- Add the four `asciidork-*` crates to `tracey-core/Cargo.toml` under `asciidoc-spec`
+  feature flag.
+- Add `asciidoc/mod.rs` sub-module structure:
+  ```
+  crates/tracey-core/src/spec/asciidoc/
+    mod.rs        — current public API (parse, render_display, etc.) wired to new internals
+    ast_walk.rs   — requirement/heading/span extraction from the asciidork AST
+    backend.rs    — TraceyAdocBackend
+  ```
+  Keep the existing `asciidoc.rs` as a flat file until the new code is ready, then
+  replace it with the directory form in the same commit.
+- Add `#[cfg(feature = "asciidoc-spec")]` guards. When the feature is off, `parse()`
+  returns a `<pre class="asciidoc-placeholder">` stub (mirrors the pattern established
+  for Typst in `asciidoc-plan.md`).
+- Write AST shape tests:
+  ```rust
+  #[cfg(all(test, feature = "asciidoc-spec"))]
+  mod ast_shape_tests {
+      // Parse paragraph-form and quote-block-form markers.
+      // Walk the AST and print/assert the Block variant and InlineNode structure.
+      // These tests exist to validate assumptions before extraction code is written.
+  }
+  ```
+- **Nothing in the existing public API changes.** All existing tests continue to pass
+  because `asciidoc.rs` still exists and is unchanged.
+
+---
+
+### Commit 2 — `ast_walk.rs`: requirement and heading extraction
+
+Implement `ast_walk.rs` with a function:
+
+```rust
+pub struct AstWalkResult {
+    pub reqs: Vec<ReqDefinition>,
+    pub headings: Vec<Heading>,
+    pub elements: Vec<DocElement>,
+    pub inline_code_spans: Vec<InlineCodeSpan>,
+    pub weight: i32,
+}
+
+pub fn walk(doc: &asciidork_ast::Document, source: &str, alloc: &mut SlugAllocator)
+    -> eyre::Result<AstWalkResult>
+```
+
+**Heading extraction:**
+- Walk `Block::Section` nodes (or equivalent in asciidork). Each section has a title
+  and a nesting level.
+- Call `alloc.alloc(&marq::slugify(&title))` to get a globally unique slug — same as
+  the current hand-rolled code.
+- Build `marq::Heading { title, id, level, line }`.
+
+**Requirement extraction:**
+- For each `Block::Paragraph` (and the first paragraph inside a `Block::Quote` /
+  delimited quote block):
+  - Collect the inline text of the first inline node.
+  - Call the existing `parse_req_leading_marker(text)` helper (moved from the current
+    `asciidoc.rs` — it is format-agnostic text logic, not parsing logic).
+  - If it matches: parse the ID via `parse_req_marker_inner`, compute `anchor_id`,
+    build `ReqDefinition`.
+  - If it does not match: build a `DocElement::Paragraph`.
+- Source spans: use the source location info from the asciidork AST nodes (they carry
+  byte offsets) rather than the hand-rolled `find_line_offset_in_content` heuristic.
+  Confirm asciidork exposes source locations — if not, fall back to searching `source`
+  for the marker text.
+
+**`parse_weight` extraction:**
+- Read from the parsed document's header attributes (`document.header.attributes`
+  or equivalent). Look for the `weight` attribute value. Fall back to scanning for
+  YAML/TOML frontmatter using `marq::parse_frontmatter` as now.
+
+**Inline code span extraction:**
+- Walk inline nodes for monospace/backtick spans. In the asciidork AST these are
+  `InlineNode::Mono` (or `InlineContent::Mono`) with source spans. Use those directly
+  instead of the hand-rolled backtick scanner.
+
+Write unit tests in `ast_walk.rs` covering the same cases as the current `asciidoc.rs`
+inline tests:
+- Heading extraction (level, title, slug)
+- Paragraph-form requirement marker
+- Quote-block-form requirement marker
+- Inline-marker not treated as requirement (the marker is not at the leading position)
+- Duplicate detection (same-file error)
+- `parse_weight` from document attribute
+- `parse_weight` from YAML frontmatter
+
+---
+
+### Commit 3 — `backend.rs`: `TraceyAdocBackend` + update `mod.rs`
+
+**`backend.rs`**
+
+Implement `TraceyAdocBackend` by implementing the `asciidork_backend::Backend` trait.
+The backend wraps `asciidork_dr_html_backend::HtmlBackend` and intercepts blocks that
+contain requirement markers.
+
+```rust
+pub struct TraceyAdocBackend<'a> {
+    inner: asciidork_dr_html_backend::HtmlBackend,
+    req_renderer: &'a dyn Fn(&ReqDefinition) -> (String, String),
+    reqs: Vec<ReqDefinition>,        // populated during traversal
+    headings: Vec<Heading>,
+    elements: Vec<DocElement>,
+    slug_alloc: &'a mut SlugAllocator,
+    html: String,
+}
+```
+
+The `Backend` trait has methods called for each AST node. For blocks that match
+requirement paragraphs:
+1. Emit the `open_html` from `req_renderer`.
+2. Delegate the block's body rendering to `inner` (the dr-html backend).
+3. Emit the `close_html`.
+
+For all other blocks: delegate to `inner` unchanged.
+
+This is structurally analogous to how marq's `TraceyRuleHandler` intercepts requirement
+blocks during pulldown-cmark event processing. The key difference is that asciidork uses
+a visitor/callback model over an AST rather than an event stream; the same intent applies.
+
+**`mod.rs` — update `parse()` and `render_display()`**
+
+`parse()` (cheap path, no badge injection):
+```rust
+pub(super) async fn parse(content: &str) -> eyre::Result<SpecDoc> {
+    #[cfg(feature = "asciidoc-spec")]
+    {
+        let arena = bumpalo::Bump::new();
+        let ast = asciidork_parser::Parser::new(content, &arena).parse()?;
+        let mut alloc = SlugAllocator::new();
+        let walk = ast_walk::walk(&ast, content, &mut alloc)?;
+        let req_renderer = |req: &ReqDefinition| uncovered_div_html(req);
+        let mut backend = backend::TraceyAdocBackend::new_cheap(&req_renderer, &mut alloc);
+        backend.render(&ast)?;
+        Ok(walk_and_backend_to_doc(walk, backend))
+    }
+    #[cfg(not(feature = "asciidoc-spec"))]
+    {
+        Ok(placeholder_doc(content))
+    }
+}
+```
+
+`render_display()` (rich path, badge injection):
+```rust
+pub async fn render_display(
+    content: &str,
+    _source_path: &Path,
+    ctx: &RenderCtx<'_>,
+    alloc: &mut SlugAllocator,
+    _deps: &mut HashSet<PathBuf>,
+) -> eyre::Result<SpecDoc> {
+    #[cfg(feature = "asciidoc-spec")]
+    {
+        let arena = bumpalo::Bump::new();
+        let ast = asciidork_parser::Parser::new(content, &arena).parse()?;
+        let walk = ast_walk::walk(&ast, content, alloc)?;
+        let mut backend = backend::TraceyAdocBackend::new_display(ctx.badge_for, alloc);
+        backend.render(&ast)?;
+        Ok(walk_and_backend_to_doc(walk, backend))
+    }
+    #[cfg(not(feature = "asciidoc-spec"))]
+    {
+        Ok(placeholder_doc(content))
+    }
+}
+```
+
+`walk_and_backend_to_doc` merges the `AstWalkResult` and backend output into a
+`marq::Document`:
+```rust
+fn walk_and_backend_to_doc(walk: AstWalkResult, backend: TraceyAdocBackend) -> SpecDoc {
+    marq::Document {
+        raw_metadata: None,
+        metadata_format: None,
+        frontmatter: None,
+        html: backend.html,
+        headings: walk.headings,
+        reqs: walk.reqs,
+        code_samples: Vec::new(),
+        elements: walk.elements,
+        head_injections: Vec::new(),
+        inline_code_spans: walk.inline_code_spans,
+    }
+}
+```
+
+**Delete the hand-rolled parser code.** `parse_inner`, `flush_paragraph`,
+`flush_quote_block`, `render_paragraph_html`, `render_blockquote_html`, `BlockState`,
+`ParseOutput`, `collect_inline_code_spans`, `heading_level`, `find_line_offset_in_content`
+all go away. The helpers that survive are:
+- `parse_req_leading_marker` — moved to `ast_walk.rs`
+- `parse_req_marker_inner` — moved to `ast_walk.rs`
+- `html_escape` — removed (asciidork's backend handles escaping)
+- `strip_frontmatter` / `find_frontmatter_end` — removed (handled by asciidork or by
+  `marq::parse_frontmatter` in `parse_weight`)
+
+The public-facing helpers (`diff_inline`, `parse_weight`, `extract_marker_prefix`,
+`id_range_in_marker`, `RenderCtx`) are kept as-is. Their signatures do not change.
+
+---
+
+### Commit 4 — Tests, update existing fixtures
+
+- Update the unit tests in `asciidoc/mod.rs` (currently in `asciidoc.rs`) to reflect
+  the new implementation paths.
+- Add tests covering things the hand-rolled parser could not handle:
+  - Table rendering (no longer garbled)
+  - Admonition blocks (`NOTE:`, `TIP:`, etc.)
+  - Ordered and unordered lists
+  - Inline formatting (bold, italic, monospace)
+  - Nested quote blocks
+  - Requirements inside list items (edge case — confirm expected behavior: should they
+    be recognized as requirements or treated as list-item text? Mirror the Markdown rule:
+    only column-0 / direct-block-child markers count.)
+- Update `crates/tracey/tests/fixtures-asciidoc/spec.adoc` to include a table and an
+  admonition block, verifying they render correctly in the integration test.
+- Run `cargo test --test asciidoc_spec_tests` and `cargo test --test watcher_tests`.
+- Verify `cargo clippy --all-targets --all-features` is clean.
+
+---
+
+## 6. Open questions to resolve in commit 1
+
+1. **asciidork AST node names.** The exact names for `Block::Paragraph`,
+   `Block::Quote`, `InlineNode`, and source span accessors must be confirmed from
+   `asciidork-ast`'s docs. The plan above uses plausible names; adjust during
+   implementation.
+
+2. **Backend trait shape.** Confirm whether `asciidork-backend::Backend` uses a
+   visitor/callback model (per-node methods) or a single `render(doc) -> String` call.
+   If it is a single-call renderer, `TraceyAdocBackend` will need to pre-walk the AST
+   for requirements and then post-process the rendered HTML to inject wrappers — less
+   clean but workable.
+
+3. **bumpalo arena lifetime.** The asciidork parser is arena-allocated. The arena must
+   outlive the AST. Because `parse()` and `render_display()` are `async fn`, confirm
+   that `bumpalo::Bump` can be created inside an async context (it is `!Send`, which
+   may interact with async executors). If necessary, wrap the parse + walk in a
+   `tokio::task::spawn_blocking` call.
+
+4. **Source span availability.** If asciidork AST nodes do not carry byte offsets,
+   `ReqDefinition::span` and `marker_span` cannot be populated accurately. The fallback
+   is the existing `find_line_offset_in_content` heuristic. Prefer native offsets if
+   available.
+
+5. **`parse_weight` attribute name.** Confirm that asciidork exposes parsed document
+   attributes in a form that allows reading arbitrary user-defined attributes (`:weight:
+   10` is a custom attribute, not a built-in AsciiDoc one). If not exposed, fall back to
+   scanning the raw content with `marq::parse_frontmatter` as today.
+
+---
+
+## 7. What does not change
+
+| Thing | Status |
+|---|---|
+| `spec/mod.rs` public API | Unchanged |
+| `SpecFormat::AsciiDoc` variant | Unchanged |
+| `SPEC_EXTENSIONS` list | Unchanged |
+| `diff_inline` | Unchanged (delegates to marq) |
+| `extract_marker_prefix` / `id_range_in_marker` | Unchanged (shared helpers) |
+| `RenderCtx` shape | Unchanged |
+| `data.rs` `load_spec_content` | Unchanged |
+| `lib.rs` extraction loop | Unchanged |
+| `daemon/service.rs` | Unchanged |
+| `search.rs` | Unchanged |
+| All integration tests in `asciidoc_spec_tests.rs` | Must continue to pass |
+| `REQ_ANCHOR_PREFIX = "r--"` contract | Unchanged |
+| `SlugAllocator` threading | Unchanged — still passed into `render_display` |
+
+---
+
+## 8. Risks
+
+**asciidork's requirement-marker handling.** `asciidork-parser` does not know about
+tracey's `r[id]` syntax. If asciidork treats the leading `r[auth.login]` line as
+something other than a plain paragraph (e.g., an inline macro, an anchor, or an
+attribute reference), requirement extraction will fail silently. Verify in commit 1's
+AST shape tests.
+
+**bumpalo + async.** Arena-allocated parsers can be awkward in async contexts. If
+`bumpalo::Bump` is `!Send`, `parse()` and `render_display()` may need to do the parse
+work on a blocking thread and return only the `Send`-safe `marq::Document`.
+
+**HTML output divergence.** `asciidork-dr-html-backend` produces Asciidoctor-compatible
+HTML5 with its own class names and structure. Existing CSS in the tracey dashboard that
+styles spec-content HTML may need updates to match the new element shapes (e.g., section
+wrapper divs, admonition block structure). Audit the dashboard CSS after commit 3.
+
+**Version stability.** `asciidork-parser` is at v0.38 with a fast release cadence. Pin
+an exact version initially (`= "0.38"`) to avoid surprise breakage; relax to `"0"` once
+the integration is stable.


### PR DESCRIPTION
This is a draft PR that adds support for asciidoc formatted spec files. It was written considering #185 as an inspiration.

This was largely implemented by claude, I've included the original plan (`asciidoc_plan.md`) for review, as well as one major rework that was done post-original plan (`unhand-plan.md`), which removed a hand-rolled parser that claude originally wrote, in favor of using `asciidork`'s parser instead.

I'm going to take this for a spin and see if it generally works, but an initial smoke test shows it is at least partially working:

<img width="935" height="722" alt="Screenshot 2026-05-01 at 5 44 39 PM" src="https://github.com/user-attachments/assets/b7e474c4-7707-4eaa-a0d0-31cf3312c7e0" />
