### PR TITLE
feat: add Svelte support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-css"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356459e8f05e0d34f11130105a8b41b9ca8d50026d8491de9f8943e46fe4f4d8"
+checksum = "d348ac9a07e57c2f0c128df5664cd7dfbfb46fefdfa17ced5d596a9bdcf3180b"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -365,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-html"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10dc4b68331e73185be5ecefa85f14ddbc4cf708c387650046826b04811b7596"
+checksum = "f99b9ab2ed6c838ef2c9c8dea0d955d32bcf742a6d51789216437fbb29ff0bfe"
 dependencies = [
  "arborium-css",
  "arborium-javascript",
@@ -400,10 +400,11 @@ dependencies = [
 
 [[package]]
 name = "arborium-javascript"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bc4cd42b968c2ba2dbac049ce7e9c94611cad1ff13c0b1dc8c84b0f314f1ce"
+checksum = "b32a315f136b2ad968ab89c098ebca47c84d37ac0d7d4daec4e7cf3d57a64eba"
 dependencies = [
+ "arborium-jsdoc",
  "arborium-sysroot",
  "cc",
  "tree-sitter-language",
@@ -414,6 +415,17 @@ name = "arborium-jinja2"
 version = "2.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e48811161ee5bd7c70f1724f02e3664e0bfbb5cc3c1f94759988530c6571a6"
+dependencies = [
+ "arborium-sysroot",
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "arborium-jsdoc"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c0a28178789b88d6bd24d509afa821346720063d2c19a8a0bcc3706ac6c014a"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -634,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-scss"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47d2baa433b72c246ef968a078600996c6d761555c3fd7f5b837bfd68cca81f"
+checksum = "082c83ab44bdbc076caae543f7e8a240f0bfaf6f69b1f3d45d891049ee0aa353"
 dependencies = [
  "arborium-css",
  "arborium-sysroot",
@@ -668,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-svelte"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7060d215677a3e0831f4bd7de963f9d01d21977aa5ece0ada366f71facefcc1"
+checksum = "e23a05acb8391afd6b9cc3b6fa088cca181ce683014e6437a5807cd5d240734a"
 dependencies = [
  "arborium-css",
  "arborium-html",
@@ -695,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-sysroot"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43374e79fbeaedc2bf27eed475c26686c8ed8eef2180854eef22340b9e25b64a"
+checksum = "260e0358abe4ede3af8b4df7a311bc9b6e4a60e4bd50af16deddfcd13759a908"
 dependencies = [
  "cc",
  "dlmalloc",
@@ -770,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-typescript"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f0bd47142ea2f37a5e72e3543c0ce1250ab76ac5bbe8288d7cf4638784ad432"
+checksum = "93dc3d802fe4b15b76f6723a53eb3d2eb147bf61175c9e995537cc0d9d934d6c"
 dependencies = [
  "arborium-javascript",
  "arborium-sysroot",
@@ -4498,6 +4510,7 @@ dependencies = [
  "arborium-r",
  "arborium-ruby",
  "arborium-rust",
+ "arborium-svelte",
  "arborium-swift",
  "arborium-typescript",
  "arborium-vb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ arborium = { version = "2.16.0", features = [
   "lang-cmake",
   "lang-nix",
   "lang-lean",
+  "lang-svelte",
 ] }
 arborium-rust = "2.16.0"
 arborium-swift = "2.16.0"
@@ -127,6 +128,7 @@ arborium-ocaml = "2.16.0"
 arborium-bash = "2.16.0"
 arborium-nix = "2.16.0"
 arborium-lean = "2.16.0"
+arborium-svelte = "2.17.0"
 
 # HTTP server for serve command
 axum = { version = "0.8", features = ["ws"] }

--- a/crates/tracey-core/Cargo.toml
+++ b/crates/tracey-core/Cargo.toml
@@ -52,6 +52,7 @@ reverse = [
   "dep:arborium-bash",
   "dep:arborium-nix",
   "dep:arborium-lean",
+  "dep:arborium-svelte",
 ]
 
 [dependencies]
@@ -96,3 +97,4 @@ arborium-ocaml = { workspace = true, optional = true }
 arborium-bash = { workspace = true, optional = true }
 arborium-nix = { workspace = true, optional = true }
 arborium-lean = { workspace = true, optional = true }
+arborium-svelte = { workspace = true, optional = true }

--- a/crates/tracey-core/src/code_units.rs
+++ b/crates/tracey-core/src/code_units.rs
@@ -180,6 +180,7 @@ pub fn extract(path: &Path, source: &str) -> CodeUnits {
         "sh" | "bash" | "zsh" => extract_bash(path, source),
         "nix" => extract_nix(path, source),
         "lean" => extract_lean(path, source),
+        "svelte" => extract_svelte(path, source),
         _ => CodeUnits::new(),
     }
 }
@@ -1120,6 +1121,31 @@ fn lean_node_kind(kind: &str) -> Option<CodeUnitKind> {
     }
 }
 
+/// Extract code units from Svelte source code
+pub fn extract_svelte(path: &Path, source: &str) -> CodeUnits {
+    let mut parser = Parser::new();
+    parser
+        .set_language(&arborium_svelte::language().into())
+        .expect("Failed to load Svelte grammar");
+
+    let Some(tree) = parser.parse(source, None) else {
+        return CodeUnits::new();
+    };
+
+    let mut units = CodeUnits::new();
+    let root = tree.root_node();
+    extract_units_recursive(path, source, root, &mut units, svelte_node_kind);
+    units
+}
+
+fn svelte_node_kind(kind: &str) -> Option<CodeUnitKind> {
+    match kind {
+        "snippet_statement" => Some(CodeUnitKind::Function),
+        "script_element" => Some(CodeUnitKind::Module),
+        _ => None,
+    }
+}
+
 fn extract_units_recursive<F>(
     path: &Path,
     source: &str,
@@ -1522,6 +1548,7 @@ pub fn extract_refs_with_warnings(path: &Path, source: &str) -> ExtractedRefs {
         "ml" | "mli" => arborium_ocaml::language(),
         "sh" | "bash" | "zsh" => arborium_bash::language(),
         "nix" => arborium_nix::language(),
+        "svelte" => arborium_svelte::language(),
         _ => return ExtractedRefs::default(),
     };
 

--- a/crates/tracey-core/src/sources.rs
+++ b/crates/tracey-core/src/sources.rs
@@ -81,6 +81,8 @@ pub const SUPPORTED_EXTENSIONS: &[&str] = &[
     "bash",   // Bash
     "zsh",    // Zsh
     "nix",    // Nix
+    "lean",   // Lean
+    "svelte", // Svelte
 ];
 
 /// Check if a file extension is supported for scanning
@@ -539,6 +541,8 @@ mod tests {
         assert!(is_supported_extension(OsStr::new("go")));
         assert!(is_supported_extension(OsStr::new("php")));
         assert!(is_supported_extension(OsStr::new("nix")));
+        assert!(is_supported_extension(OsStr::new("lean")));
+        assert!(is_supported_extension(OsStr::new("svelte")));
 
         assert!(!is_supported_extension(OsStr::new("md")));
         assert!(!is_supported_extension(OsStr::new("txt")));

--- a/crates/tracey/src/daemon/service.rs
+++ b/crates/tracey/src/daemon/service.rs
@@ -214,6 +214,8 @@ fn arborium_language(path: &str) -> Option<&'static str> {
         "cmake" => Some("cmake"),
         // MATLAB
         "mat" => Some("matlab"),
+        // Svelte
+        "svelte" => Some("svelte"),
         _ => None,
     }
 }


### PR DESCRIPTION
Inspired by the changes in #186, I've added Svelte support. I noticed `crates/tracey-core/src/sources.rs` was missing the `lean` extension so I added that as well.