### PR TITLE
Add `all` query command to export rules with full text

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ tracey query uncovered           # rules with no impl references
 tracey query untested            # rules with impl but no verify references
 tracey query stale               # references pointing to older rule versions
 tracey query unmapped            # source tree with coverage percentages
+tracey query all                 # list every rule (use --json for full bodies)
 tracey query rule auth.login     # full details for a specific rule
 tracey query validate            # check for broken refs, naming issues
 tracey query validate --deny warnings # also fail on warnings

--- a/README.md.in
+++ b/README.md.in
@@ -186,6 +186,7 @@ tracey query uncovered           # rules with no impl references
 tracey query untested            # rules with impl but no verify references
 tracey query stale               # references pointing to older rule versions
 tracey query unmapped            # source tree with coverage percentages
+tracey query all                 # list every rule (use --json for full bodies)
 tracey query rule auth.login     # full details for a specific rule
 tracey query validate            # check for broken refs, naming issues
 tracey query validate --deny warnings # also fail on warnings

--- a/crates/tracey-proto/src/lib.rs
+++ b/crates/tracey-proto/src/lib.rs
@@ -14,7 +14,7 @@ pub use tracey_api::*;
 /// Protocol version — bump this whenever any RPC method is added, removed, or changed.
 /// The daemon writes this into its PID file; connectors compare it before connecting
 /// to detect stale daemons running an incompatible build.
-pub const PROTOCOL_VERSION: u32 = 4;
+pub const PROTOCOL_VERSION: u32 = 5;
 
 // ============================================================================
 // Request/Response types for the TraceyDaemon service
@@ -83,6 +83,29 @@ pub struct UntestedResponse {
     pub impl_name: String,
     pub total_rules: usize,
     pub untested_count: usize,
+    pub by_section: Vec<SectionRules>,
+}
+
+/// Request for all-rules query
+#[derive(Debug, Clone, Facet)]
+#[facet(rename_all = "camelCase")]
+pub struct AllRequest {
+    #[facet(default)]
+    pub spec: Option<String>,
+    #[facet(default)]
+    pub impl_name: Option<String>,
+    #[facet(default)]
+    pub prefix: Option<String>,
+}
+
+/// Response for all-rules query.
+/// Returns every rule in the spec/impl with its body text populated.
+#[derive(Debug, Clone, Facet)]
+#[facet(rename_all = "camelCase")]
+pub struct AllResponse {
+    pub spec: String,
+    pub impl_name: String,
+    pub total_rules: usize,
     pub by_section: Vec<SectionRules>,
 }
 
@@ -654,6 +677,9 @@ pub trait TraceyDaemon {
 
     /// Get untested rules (rules with impl but no verify references)
     async fn untested(&self, req: UntestedRequest) -> UntestedResponse;
+
+    /// Get every rule in a spec/impl, with body text populated.
+    async fn all(&self, req: AllRequest) -> AllResponse;
 
     /// Get stale references (code pointing to older rule versions)
     async fn stale(&self, req: StaleRequest) -> StaleResponse;

--- a/crates/tracey/src/bridge/query.rs
+++ b/crates/tracey/src/bridge/query.rs
@@ -368,6 +368,50 @@ impl QueryClient {
         self.with_config_banner(output).await
     }
 
+    /// List every rule in a spec/impl with body text.
+    pub async fn all(&self, spec_impl: Option<&str>, prefix: Option<&str>) -> String {
+        let (spec, impl_name) = match self.checked_spec_impl(spec_impl).await {
+            Ok(values) => values,
+            Err(error) => return self.with_config_banner(format!("Error: {error}")).await,
+        };
+
+        let req = AllRequest {
+            spec,
+            impl_name,
+            prefix: prefix.map(String::from),
+        };
+
+        let output = match self.client.all(req).await {
+            Ok(response) => {
+                let mut output = format!(
+                    "{}/{}: {} rules total\n\n",
+                    response.spec, response.impl_name, response.total_rules
+                );
+
+                for section in &response.by_section {
+                    if !section.rules.is_empty() {
+                        output.push_str(&format!("## {}\n", section.section));
+                        for rule in &section.rules {
+                            output.push_str(&format!("  - {}\n", rule.id));
+                        }
+                        output.push('\n');
+                    }
+                }
+
+                output.push_str("---\n");
+                output.push_str(&self.hint(
+                    "tracey query all",
+                    "tracey query to list all rules with body text",
+                ));
+
+                output
+            }
+            Err(e) => format!("Error: {e:?}"),
+        };
+
+        self.with_config_banner(output).await
+    }
+
     /// Get code units without rule references
     pub async fn unmapped(&self, spec_impl: Option<&str>, path: Option<&str>) -> String {
         let (spec, impl_name) = match self.checked_spec_impl(spec_impl).await {

--- a/crates/tracey/src/bridge/query.rs
+++ b/crates/tracey/src/bridge/query.rs
@@ -368,7 +368,7 @@ impl QueryClient {
         self.with_config_banner(output).await
     }
 
-    /// List every rule in a spec/impl with body text.
+    /// List every rule in a spec/impl, grouped by section.
     pub async fn all(&self, spec_impl: Option<&str>, prefix: Option<&str>) -> String {
         let (spec, impl_name) = match self.checked_spec_impl(spec_impl).await {
             Ok(values) => values,
@@ -401,7 +401,7 @@ impl QueryClient {
                 output.push_str("---\n");
                 output.push_str(&self.hint(
                     "tracey query all",
-                    "tracey query to list all rules with body text",
+                    "tracey query to list every rule grouped by section",
                 ));
 
                 output

--- a/crates/tracey/src/daemon/client.rs
+++ b/crates/tracey/src/daemon/client.rs
@@ -123,6 +123,12 @@ impl DaemonClient {
         self.with_client(|c| async move { c.untested(req).await })
             .await
     }
+    pub async fn all(
+        &self,
+        req: tracey_proto::AllRequest,
+    ) -> Result<tracey_proto::AllResponse, vox::VoxError> {
+        self.with_client(|c| async move { c.all(req).await }).await
+    }
     pub async fn stale(
         &self,
         req: tracey_proto::StaleRequest,

--- a/crates/tracey/src/daemon/service.rs
+++ b/crates/tracey/src/daemon/service.rs
@@ -322,6 +322,44 @@ impl TraceyDaemon for TraceyService {
         }
     }
 
+    /// Get every rule with body text populated
+    async fn all(&self, req: AllRequest) -> AllResponse {
+        let data = self.inner.engine.data().await;
+        let query = QueryEngine::new(&data);
+
+        let (spec, impl_name) =
+            self.resolve_spec_impl(req.spec.as_deref(), req.impl_name.as_deref(), &data.config);
+
+        if let Some(result) = query.all(&spec, &impl_name, req.prefix.as_deref()) {
+            AllResponse {
+                spec: result.spec,
+                impl_name: result.impl_name,
+                total_rules: result.total_rules,
+                by_section: result
+                    .by_section
+                    .into_iter()
+                    .map(|(section, rules)| SectionRules {
+                        section,
+                        rules: rules
+                            .into_iter()
+                            .map(|r| tracey_proto::RuleRef {
+                                id: r.id,
+                                text: r.text,
+                            })
+                            .collect(),
+                    })
+                    .collect(),
+            }
+        } else {
+            AllResponse {
+                spec,
+                impl_name,
+                total_rules: 0,
+                by_section: vec![],
+            }
+        }
+    }
+
     /// Get stale references
     async fn stale(&self, req: StaleRequest) -> StaleResponse {
         let data = self.inner.engine.data().await;

--- a/crates/tracey/src/main.rs
+++ b/crates/tracey/src/main.rs
@@ -246,6 +246,17 @@ enum QueryCommand {
         prefix: Option<String>,
     },
 
+    /// List every rule in a spec/impl with body text (designed for --json export)
+    All {
+        /// Spec/impl to query (e.g., "my-spec/rust"). Optional if only one exists.
+        #[facet(args::named, default)]
+        spec_impl: Option<String>,
+
+        /// Filter by rule ID prefix
+        #[facet(args::named, default)]
+        prefix: Option<String>,
+    },
+
     /// Show unmapped code units
     Unmapped {
         /// Spec/impl to query (e.g., "my-spec/rust"). Optional if only one exists.
@@ -508,6 +519,12 @@ async fn main() -> Result<()> {
                         .await,
                     false,
                 ),
+                QueryCommand::All { spec_impl, prefix } => (
+                    query_client
+                        .all(spec_impl.as_deref(), prefix.as_deref())
+                        .await,
+                    false,
+                ),
                 QueryCommand::Unmapped { spec_impl, path } => (
                     query_client
                         .unmapped(spec_impl.as_deref(), path.as_deref())
@@ -628,6 +645,35 @@ async fn query_json(qc: &bridge::query::QueryClient, query: QueryCommand) -> (St
                 prefix,
             };
             match qc.client.untested(req).await {
+                Ok(resp) => (
+                    facet_json::to_string_pretty(&resp).expect("JSON serialization failed"),
+                    false,
+                ),
+                Err(e) => (json_error(&format!("{e:?}")), false),
+            }
+        }
+        QueryCommand::All { spec_impl, prefix } => {
+            let (spec, impl_name) = match spec_impl.as_deref() {
+                Some(raw) => {
+                    let config = match qc.client.config().await {
+                        Ok(config) => config,
+                        Err(e) => {
+                            return (json_error(&format!("failed to load config: {e:?}")), false);
+                        }
+                    };
+                    match validate_spec_impl_selection(Some(raw), &config) {
+                        Ok(values) => values,
+                        Err(error) => return (json_error(&error), false),
+                    }
+                }
+                None => parse_spec_impl(None),
+            };
+            let req = AllRequest {
+                spec,
+                impl_name,
+                prefix,
+            };
+            match qc.client.all(req).await {
                 Ok(resp) => (
                     facet_json::to_string_pretty(&resp).expect("JSON serialization failed"),
                     false,

--- a/crates/tracey/src/main.rs
+++ b/crates/tracey/src/main.rs
@@ -246,7 +246,7 @@ enum QueryCommand {
         prefix: Option<String>,
     },
 
-    /// List every rule in a spec/impl with body text (designed for --json export)
+    /// List every rule in a spec/impl, grouped by section
     All {
         /// Spec/impl to query (e.g., "my-spec/rust"). Optional if only one exists.
         #[facet(args::named, default)]
@@ -580,10 +580,29 @@ fn json_error(message: &str) -> String {
     .expect("JSON serialization failed")
 }
 
+/// Resolve `--spec_impl` for JSON-mode queries. Returns the parsed
+/// `(spec, impl)` pair, or a ready-to-return JSON error string if the
+/// daemon config call or spec/impl validation fails.
+async fn resolve_spec_impl_for_json(
+    qc: &bridge::query::QueryClient,
+    spec_impl: Option<&str>,
+) -> Result<(Option<String>, Option<String>), String> {
+    use bridge::query::{parse_spec_impl, validate_spec_impl_selection};
+    let Some(raw) = spec_impl else {
+        return Ok(parse_spec_impl(None));
+    };
+    let config = qc
+        .client
+        .config()
+        .await
+        .map_err(|e| json_error(&format!("failed to load config: {e:?}")))?;
+    validate_spec_impl_selection(Some(raw), &config).map_err(|e| json_error(&e))
+}
+
 /// Handle `tracey query --json <subcommand>` by calling the daemon client
 /// directly and serializing the typed response as JSON.
 async fn query_json(qc: &bridge::query::QueryClient, query: QueryCommand) -> (String, bool) {
-    use bridge::query::{parse_spec_impl, validate_spec_impl_selection};
+    use bridge::query::validate_spec_impl_selection;
     use tracey_proto::*;
 
     match query {
@@ -595,20 +614,10 @@ async fn query_json(qc: &bridge::query::QueryClient, query: QueryCommand) -> (St
             Err(e) => (json_error(&format!("{e:?}")), false),
         },
         QueryCommand::Uncovered { spec_impl, prefix } => {
-            let (spec, impl_name) = match spec_impl.as_deref() {
-                Some(raw) => {
-                    let config = match qc.client.config().await {
-                        Ok(config) => config,
-                        Err(e) => {
-                            return (json_error(&format!("failed to load config: {e:?}")), false);
-                        }
-                    };
-                    match validate_spec_impl_selection(Some(raw), &config) {
-                        Ok(values) => values,
-                        Err(error) => return (json_error(&error), false),
-                    }
-                }
-                None => parse_spec_impl(None),
+            let (spec, impl_name) = match resolve_spec_impl_for_json(qc, spec_impl.as_deref()).await
+            {
+                Ok(v) => v,
+                Err(err) => return (err, false),
             };
             let req = UncoveredRequest {
                 spec,
@@ -624,20 +633,10 @@ async fn query_json(qc: &bridge::query::QueryClient, query: QueryCommand) -> (St
             }
         }
         QueryCommand::Untested { spec_impl, prefix } => {
-            let (spec, impl_name) = match spec_impl.as_deref() {
-                Some(raw) => {
-                    let config = match qc.client.config().await {
-                        Ok(config) => config,
-                        Err(e) => {
-                            return (json_error(&format!("failed to load config: {e:?}")), false);
-                        }
-                    };
-                    match validate_spec_impl_selection(Some(raw), &config) {
-                        Ok(values) => values,
-                        Err(error) => return (json_error(&error), false),
-                    }
-                }
-                None => parse_spec_impl(None),
+            let (spec, impl_name) = match resolve_spec_impl_for_json(qc, spec_impl.as_deref()).await
+            {
+                Ok(v) => v,
+                Err(err) => return (err, false),
             };
             let req = UntestedRequest {
                 spec,
@@ -653,20 +652,10 @@ async fn query_json(qc: &bridge::query::QueryClient, query: QueryCommand) -> (St
             }
         }
         QueryCommand::All { spec_impl, prefix } => {
-            let (spec, impl_name) = match spec_impl.as_deref() {
-                Some(raw) => {
-                    let config = match qc.client.config().await {
-                        Ok(config) => config,
-                        Err(e) => {
-                            return (json_error(&format!("failed to load config: {e:?}")), false);
-                        }
-                    };
-                    match validate_spec_impl_selection(Some(raw), &config) {
-                        Ok(values) => values,
-                        Err(error) => return (json_error(&error), false),
-                    }
-                }
-                None => parse_spec_impl(None),
+            let (spec, impl_name) = match resolve_spec_impl_for_json(qc, spec_impl.as_deref()).await
+            {
+                Ok(v) => v,
+                Err(err) => return (err, false),
             };
             let req = AllRequest {
                 spec,
@@ -682,20 +671,10 @@ async fn query_json(qc: &bridge::query::QueryClient, query: QueryCommand) -> (St
             }
         }
         QueryCommand::Stale { spec_impl, prefix } => {
-            let (spec, impl_name) = match spec_impl.as_deref() {
-                Some(raw) => {
-                    let config = match qc.client.config().await {
-                        Ok(config) => config,
-                        Err(e) => {
-                            return (json_error(&format!("failed to load config: {e:?}")), false);
-                        }
-                    };
-                    match validate_spec_impl_selection(Some(raw), &config) {
-                        Ok(values) => values,
-                        Err(error) => return (json_error(&error), false),
-                    }
-                }
-                None => parse_spec_impl(None),
+            let (spec, impl_name) = match resolve_spec_impl_for_json(qc, spec_impl.as_deref()).await
+            {
+                Ok(v) => v,
+                Err(err) => return (err, false),
             };
             let req = StaleRequest {
                 spec,
@@ -711,20 +690,10 @@ async fn query_json(qc: &bridge::query::QueryClient, query: QueryCommand) -> (St
             }
         }
         QueryCommand::Unmapped { spec_impl, path } => {
-            let (spec, impl_name) = match spec_impl.as_deref() {
-                Some(raw) => {
-                    let config = match qc.client.config().await {
-                        Ok(config) => config,
-                        Err(e) => {
-                            return (json_error(&format!("failed to load config: {e:?}")), false);
-                        }
-                    };
-                    match validate_spec_impl_selection(Some(raw), &config) {
-                        Ok(values) => values,
-                        Err(error) => return (json_error(&error), false),
-                    }
-                }
-                None => parse_spec_impl(None),
+            let (spec, impl_name) = match resolve_spec_impl_for_json(qc, spec_impl.as_deref()).await
+            {
+                Ok(v) => v,
+                Err(err) => return (err, false),
             };
             let req = UnmappedRequest {
                 spec,

--- a/crates/tracey/src/server.rs
+++ b/crates/tracey/src/server.rs
@@ -314,6 +314,42 @@ impl<'a> QueryEngine<'a> {
         })
     }
 
+    /// Get every rule for a spec/impl with body text populated.
+    ///
+    /// Designed for machine-readable export (e.g. syncing requirements to an
+    /// external tracker). Unlike `uncovered`/`untested`, this populates each
+    /// `RuleRef.text` so callers do not need to issue a follow-up `rule()` call
+    /// per rule.
+    pub fn all(
+        &self,
+        spec: &str,
+        impl_name: &str,
+        prefix_filter: Option<&str>,
+    ) -> Option<AllResult> {
+        let key: ImplKey = (spec.to_string(), impl_name.to_string());
+        let forward = self.data.forward_by_impl.get(&key)?;
+
+        let rules: Vec<&ApiRule> = forward
+            .rules
+            .iter()
+            .filter(|r| {
+                prefix_filter
+                    .map(|p| r.id.base.to_lowercase().starts_with(&p.to_lowercase()))
+                    .unwrap_or(true)
+            })
+            .collect();
+
+        let by_section = group_rules_by_section_with_text(&rules);
+
+        Some(AllResult {
+            spec: spec.to_string(),
+            impl_name: impl_name.to_string(),
+            total_rules: rules.len(),
+            by_section,
+            prefix_filter: prefix_filter.map(|s| s.to_string()),
+        })
+    }
+
     /// Get stale references for a spec/impl, optionally filtered by rule ID prefix
     pub fn stale(
         &self,
@@ -532,9 +568,22 @@ pub struct UntestedResult {
 }
 
 #[derive(Debug, Clone)]
+pub struct AllResult {
+    pub spec: String,
+    pub impl_name: String,
+    pub by_section: BTreeMap<String, Vec<RuleRef>>,
+    pub total_rules: usize,
+    pub prefix_filter: Option<String>,
+}
+
+#[derive(Debug, Clone)]
 pub struct RuleRef {
     pub id: RuleId,
     pub impl_refs: Vec<ApiCodeRef>,
+    /// Raw markdown body of the rule. Populated only when the caller asks for it
+    /// (e.g. `all()` for machine-readable export); `None` for the lightweight
+    /// summary commands (`uncovered`, `untested`).
+    pub text: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -645,6 +694,17 @@ impl RuleInfo {
 // ============================================================================
 
 fn group_rules_by_section(rules: &[&ApiRule]) -> BTreeMap<String, Vec<RuleRef>> {
+    group_rules_by_section_inner(rules, false)
+}
+
+fn group_rules_by_section_with_text(rules: &[&ApiRule]) -> BTreeMap<String, Vec<RuleRef>> {
+    group_rules_by_section_inner(rules, true)
+}
+
+fn group_rules_by_section_inner(
+    rules: &[&ApiRule],
+    include_text: bool,
+) -> BTreeMap<String, Vec<RuleRef>> {
     let mut result: BTreeMap<String, Vec<RuleRef>> = BTreeMap::new();
 
     for rule in rules {
@@ -657,6 +717,11 @@ fn group_rules_by_section(rules: &[&ApiRule]) -> BTreeMap<String, Vec<RuleRef>> 
         result.entry(section).or_default().push(RuleRef {
             id: rule.id.clone(),
             impl_refs: rule.impl_refs.clone(),
+            text: if include_text {
+                Some(rule.raw.clone())
+            } else {
+                None
+            },
         });
     }
 

--- a/crates/tracey/src/server.rs
+++ b/crates/tracey/src/server.rs
@@ -265,7 +265,7 @@ impl<'a> QueryEngine<'a> {
             .collect();
 
         // Build section mapping from outline
-        let by_section = group_rules_by_section(&uncovered_rules);
+        let by_section = group_rules_by_section(&uncovered_rules, |_| None);
 
         Some(UncoveredResult {
             spec: spec.to_string(),
@@ -302,7 +302,7 @@ impl<'a> QueryEngine<'a> {
             })
             .collect();
 
-        let by_section = group_rules_by_section(&untested_rules);
+        let by_section = group_rules_by_section(&untested_rules, |_| None);
 
         Some(UntestedResult {
             spec: spec.to_string(),
@@ -314,12 +314,13 @@ impl<'a> QueryEngine<'a> {
         })
     }
 
-    /// Get every rule for a spec/impl with body text populated.
+    /// Get every rule for a spec/impl, grouped by section.
     ///
-    /// Designed for machine-readable export (e.g. syncing requirements to an
-    /// external tracker). Unlike `uncovered`/`untested`, this populates each
-    /// `RuleRef.text` so callers do not need to issue a follow-up `rule()` call
-    /// per rule.
+    /// Unlike `uncovered`/`untested`, this also populates each `RuleRef.text`
+    /// with the rule's raw markdown body — intended for machine-readable
+    /// export (e.g. syncing requirements to an external tracker) where the
+    /// caller wants every rule's body without issuing a follow-up `rule()`
+    /// call per rule.
     pub fn all(
         &self,
         spec: &str,
@@ -339,7 +340,7 @@ impl<'a> QueryEngine<'a> {
             })
             .collect();
 
-        let by_section = group_rules_by_section_with_text(&rules);
+        let by_section = group_rules_by_section(&rules, |r| Some(r.raw.clone()));
 
         Some(AllResult {
             spec: spec.to_string(),
@@ -693,17 +694,9 @@ impl RuleInfo {
 // Helpers
 // ============================================================================
 
-fn group_rules_by_section(rules: &[&ApiRule]) -> BTreeMap<String, Vec<RuleRef>> {
-    group_rules_by_section_inner(rules, false)
-}
-
-fn group_rules_by_section_with_text(rules: &[&ApiRule]) -> BTreeMap<String, Vec<RuleRef>> {
-    group_rules_by_section_inner(rules, true)
-}
-
-fn group_rules_by_section_inner(
+fn group_rules_by_section(
     rules: &[&ApiRule],
-    include_text: bool,
+    extract_text: impl Fn(&ApiRule) -> Option<String>,
 ) -> BTreeMap<String, Vec<RuleRef>> {
     let mut result: BTreeMap<String, Vec<RuleRef>> = BTreeMap::new();
 
@@ -717,11 +710,7 @@ fn group_rules_by_section_inner(
         result.entry(section).or_default().push(RuleRef {
             id: rule.id.clone(),
             impl_refs: rule.impl_refs.clone(),
-            text: if include_text {
-                Some(rule.raw.clone())
-            } else {
-                None
-            },
+            text: extract_text(rule),
         });
     }
 

--- a/crates/tracey/tests/integration_tests.rs
+++ b/crates/tracey/tests/integration_tests.rs
@@ -183,6 +183,54 @@ async fn test_uncovered_with_prefix_filter() {
 }
 
 #[tokio::test]
+async fn test_all_returns_every_rule_with_text() {
+    let service = create_test_service().await;
+    let req = AllRequest {
+        spec: Some("test".to_string()),
+        impl_name: Some("rust".to_string()),
+        prefix: None,
+    };
+
+    let response = rpc(service.client.all(req).await);
+
+    assert_eq!(response.spec, "test");
+    assert_eq!(response.impl_name, "rust");
+
+    // spec.md defines 8 rules across 3 sections.
+    let total: usize = response.by_section.iter().map(|s| s.rules.len()).sum();
+    assert_eq!(total, 8, "expected 8 rules from fixture spec.md");
+    assert_eq!(response.total_rules, 8);
+
+    // Every rule must have a non-empty body — this is the whole point of `all`.
+    for section in &response.by_section {
+        for rule in &section.rules {
+            let text = rule
+                .text
+                .as_ref()
+                .unwrap_or_else(|| panic!("rule {} missing text", rule.id));
+            assert!(!text.is_empty(), "rule {} has empty text", rule.id);
+        }
+    }
+
+    // Content fidelity: a known rule's body must match the spec markdown.
+    let login = response
+        .by_section
+        .iter()
+        .flat_map(|s| &s.rules)
+        .find(|r| r.id.base == "auth.login")
+        .expect("auth.login should be present");
+    assert!(
+        login
+            .text
+            .as_ref()
+            .unwrap()
+            .contains("valid credentials"),
+        "auth.login body should contain 'valid credentials', got: {:?}",
+        login.text
+    );
+}
+
+#[tokio::test]
 async fn test_untested_returns_rules() {
     let service = create_test_service().await;
     let req = UntestedRequest {

--- a/crates/tracey/tests/integration_tests.rs
+++ b/crates/tracey/tests/integration_tests.rs
@@ -220,14 +220,77 @@ async fn test_all_returns_every_rule_with_text() {
         .find(|r| r.id.base == "auth.login")
         .expect("auth.login should be present");
     assert!(
-        login
-            .text
-            .as_ref()
-            .unwrap()
-            .contains("valid credentials"),
+        login.text.as_ref().unwrap().contains("valid credentials"),
         "auth.login body should contain 'valid credentials', got: {:?}",
         login.text
     );
+}
+
+#[tokio::test]
+async fn test_all_json_serialization() {
+    // Mirror the `tracey query all --json` path: call the RPC and serialize
+    // the response with facet_json, asserting the wire shape downstream
+    // consumers depend on.
+    let service = create_test_service().await;
+    let req = AllRequest {
+        spec: Some("test".to_string()),
+        impl_name: Some("rust".to_string()),
+        prefix: None,
+    };
+
+    let response = rpc(service.client.all(req).await);
+    let json = facet_json::to_string_pretty(&response).expect("JSON serialization failed");
+
+    // Top-level shape (camelCase per #[facet(rename_all = "camelCase")]).
+    assert!(json.contains("\"spec\""), "missing `spec` field: {json}");
+    assert!(
+        json.contains("\"implName\""),
+        "expected camelCase `implName`: {json}"
+    );
+    assert!(
+        json.contains("\"totalRules\""),
+        "expected camelCase `totalRules`: {json}"
+    );
+    assert!(
+        json.contains("\"bySection\""),
+        "expected camelCase `bySection`: {json}"
+    );
+
+    // Body text round-trips for at least one known rule.
+    assert!(
+        json.contains("valid credentials"),
+        "expected `auth.login` body text in JSON output: {json}"
+    );
+}
+
+#[tokio::test]
+async fn test_all_with_prefix_filter() {
+    let service = create_test_service().await;
+    let req = AllRequest {
+        spec: Some("test".to_string()),
+        impl_name: Some("rust".to_string()),
+        prefix: Some("auth".to_string()),
+    };
+
+    let response = rpc(service.client.all(req).await);
+
+    let returned: Vec<_> = response.by_section.iter().flat_map(|s| &s.rules).collect();
+
+    assert!(!returned.is_empty(), "prefix `auth` should match >= 1 rule");
+    assert_eq!(response.total_rules, returned.len());
+
+    for rule in &returned {
+        assert!(
+            rule.id.base.starts_with("auth."),
+            "rule {} does not match prefix `auth`",
+            rule.id
+        );
+        let text = rule
+            .text
+            .as_ref()
+            .unwrap_or_else(|| panic!("rule {} missing text", rule.id));
+        assert!(!text.is_empty(), "rule {} has empty text", rule.id);
+    }
 }
 
 #[tokio::test]

--- a/docs/content/guide/cli-reference.md
+++ b/docs/content/guide/cli-reference.md
@@ -154,6 +154,14 @@ List references pointing to older rule versions.
 tracey query stale [--spec_impl SPEC/IMPL] [--prefix PREFIX] [ROOT]
 ```
 
+### `tracey query all`
+
+List every requirement in a spec/impl, grouped by section. In `--json` mode each rule also includes its full body text — designed for exporting requirements to external trackers.
+
+```
+tracey query all [--spec_impl SPEC/IMPL] [--prefix PREFIX] [ROOT]
+```
+
 ### `tracey query unmapped`
 
 Show source tree with coverage percentages. Code units (functions, structs, etc.) without requirement references are "unmapped."


### PR DESCRIPTION
 Hi! First time contributor here — `tracey` is a great tool, thanks for creating it! Happy to adjust anything that doesn't fit your conventions.

  ### Motivation

  I wanted a way to pull every requirement out of a spec along with its rendered body text, so I can sync requirements into an external requirements management tool. The existing query commands return rule IDs and metadata, but not the populated markdown body, which meant I'd have to re-parse the spec files myself.

  ### Change

  Adds a new subcommand:

  `tracey query all [--spec_impl <spec/impl>] [--prefix <id-prefix>] [--json]`

  It returns every rule in the selected spec/impl, grouped by section. In `--json` mode each rule also includes its populated markdown
  body — designed primarily for export, but the human-readable output works too.

  ### Implementation notes

  - Bumped the daemon protocol version to 5.
  - Added `AllRequest` / `AllResponse` to `tracey-proto`.
  - Extended `RuleRef` so rule text is optional — only the new `all` command populates it, so the lighter commands (`uncovered`,
  `untested`, etc.) are unchanged on the wire.
  - Wired the command through `main.rs`, `bridge/query.rs`, `daemon/{client,service}.rs`, and `server.rs`, mirroring the existing
  `stale` / `unmapped` query plumbing.
  - While adding the new arm, extracted a `resolve_spec_impl_for_json()` helper in `main.rs` so the five JSON query arms share one copy
   of the spec/impl validation block instead of five.
  - Replaced `group_rules_by_section_inner(rules, bool)` and its two thin wrappers with a single `group_rules_by_section(rules,
  closure)` that takes a text-extraction closure — clearer than the boolean flag, and makes the "with text" / "without text"
  distinction explicit at the call site.

  ### Tests

  Added integration coverage in `crates/tracey/tests/integration_tests.rs`:
  - `test_all_returns_every_rule_with_text` — end-to-end happy path.