### PR TITLE
Support impl annotations in YAML and JSON5 files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4509,6 +4509,7 @@ dependencies = [
  "arborium-swift",
  "arborium-typescript",
  "arborium-vb",
+ "arborium-yaml",
  "eyre",
  "facet",
  "globset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ arborium-ocaml = "2.16.0"
 arborium-bash = "2.16.0"
 arborium-nix = "2.16.0"
 arborium-lean = "2.16.0"
+arborium-yaml = "2.16.0"
 
 # HTTP server for serve command
 axum = { version = "0.8", features = ["ws"] }

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ When spec text changes and the version is bumped to `+4`, tracey reports the `+3
 
 ## Supported Languages
 
-Tracey scans comments in: Rust, Swift, TypeScript, TSX, JavaScript, JSX, Go, C, C++, Objective-C, Objective-C++, Java, Kotlin, Scala, Groovy, C#, Zig, PHP.
+Tracey scans comments in: Rust, Swift, TypeScript, TSX, JavaScript, JSX, Go, C, C++, Objective-C, Objective-C++, Java, Kotlin, Scala, Groovy, C#, Zig, PHP, YAML (`.yml`, `.yaml`).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ When spec text changes and the version is bumped to `+4`, tracey reports the `+3
 
 ## Supported Languages
 
-Tracey scans comments in: Rust, Swift, TypeScript, TSX, JavaScript, JSX, Go, C, C++, Objective-C, Objective-C++, Java, Kotlin, Scala, Groovy, C#, Zig, PHP, YAML (`.yml`, `.yaml`).
+Tracey scans comments in: Rust, Swift, TypeScript, TSX, JavaScript, JSX, Go, C, C++, Objective-C, Objective-C++, Java, Kotlin, Scala, Groovy, C#, Zig, PHP, YAML (`.yml`, `.yaml`), JSON5 (`.json5`).
 
 ## License
 

--- a/crates/tracey-core/Cargo.toml
+++ b/crates/tracey-core/Cargo.toml
@@ -52,6 +52,7 @@ reverse = [
   "dep:arborium-bash",
   "dep:arborium-nix",
   "dep:arborium-lean",
+  "dep:arborium-yaml",
 ]
 
 [dependencies]
@@ -97,3 +98,4 @@ arborium-ocaml = { workspace = true, optional = true }
 arborium-bash = { workspace = true, optional = true }
 arborium-nix = { workspace = true, optional = true }
 arborium-lean = { workspace = true, optional = true }
+arborium-yaml = { workspace = true, optional = true }

--- a/crates/tracey-core/src/code_units.rs
+++ b/crates/tracey-core/src/code_units.rs
@@ -1522,6 +1522,7 @@ pub fn extract_refs_with_warnings(path: &Path, source: &str) -> ExtractedRefs {
         "ml" | "mli" => arborium_ocaml::language(),
         "sh" | "bash" | "zsh" => arborium_bash::language(),
         "nix" => arborium_nix::language(),
+        "yml" | "yaml" => arborium_yaml::language(),
         _ => return ExtractedRefs::default(),
     };
 

--- a/crates/tracey-core/src/code_units.rs
+++ b/crates/tracey-core/src/code_units.rs
@@ -1498,7 +1498,11 @@ pub fn extract_refs_with_warnings(path: &Path, source: &str) -> ExtractedRefs {
         "go" => arborium_go::language(),
         "java" => arborium_java::language(),
         "py" => arborium_python::language(),
-        "ts" | "tsx" | "js" | "jsx" | "mts" | "cts" => arborium_typescript::language(),
+        // json5 shares // and /* */ comment syntax with JS/TS; reuse the TS grammar
+        // so that tree-sitter can identify comment nodes in the reverse path.
+        "ts" | "tsx" | "js" | "jsx" | "mts" | "cts" | "json5" => {
+            arborium_typescript::language()
+        }
         "php" => arborium_php::language(),
         "c" | "h" => arborium_c::language(),
         "cpp" | "cc" | "cxx" | "hpp" => arborium_cpp::language(),

--- a/crates/tracey-core/src/lexer.rs
+++ b/crates/tracey-core/src/lexer.rs
@@ -299,28 +299,27 @@ fn extract_from_content_text_based(path: &Path, content: &str, reqs: &mut Reqs) 
         let line_num = LineNumber::from_zero_based(line_idx);
         let line_start = line_starts.line_start_for_index(line_idx);
 
-        // Check for line comments (// or ///)
-        if let Some(comment_pos) = line.find("//") {
-            let comment = &line[comment_pos..];
-            let comment_start = line_start.add(comment_pos);
-
-            // Check ignore directives before extracting
-            if check_ignore_directives(comment, line_num, &mut ignore_state) {
-                extract_references_from_text(
-                    path,
-                    comment,
-                    comment_start,
-                    line_num,
-                    &file_code_mask,
-                    reqs,
-                );
-            }
-        }
-
-        // For YAML files, also scan # line comments.
-        // YAML uses # as its only comment syntax; // and /* */ don't apply.
         if is_yaml {
+            // YAML uses # as its only comment syntax; skip // and /* */ scanning
+            // entirely to avoid false positives (e.g. URLs containing //).
             if let Some(comment_pos) = line.find('#') {
+                let comment = &line[comment_pos..];
+                let comment_start = line_start.add(comment_pos);
+
+                if check_ignore_directives(comment, line_num, &mut ignore_state) {
+                    extract_references_from_text(
+                        path,
+                        comment,
+                        comment_start,
+                        line_num,
+                        &file_code_mask,
+                        reqs,
+                    );
+                }
+            }
+        } else {
+            // Check for line comments (// or ///)
+            if let Some(comment_pos) = line.find("//") {
                 let comment = &line[comment_pos..];
                 let comment_start = line_start.add(comment_pos);
 
@@ -338,40 +337,41 @@ fn extract_from_content_text_based(path: &Path, content: &str, reqs: &mut Reqs) 
         }
     }
 
-    // Handle block comments /* */
-    let mut in_block_comment = false;
-    let mut block_start = 0;
-    let mut block_line = LineNumber::from_one_based(1);
-    let mut i = 0;
-    let bytes = content.as_bytes();
+    // Handle block comments /* */ — not applicable to YAML.
+    if !is_yaml {
+        let mut in_block_comment = false;
+        let mut block_start = 0;
+        let mut block_line = LineNumber::from_one_based(1);
+        let mut i = 0;
+        let bytes = content.as_bytes();
 
-    while i < bytes.len() {
-        if in_block_comment {
-            if i + 1 < bytes.len() && bytes[i] == b'*' && bytes[i + 1] == b'/' {
-                let block_content = &content[block_start..i];
-                // Check ignore directives for block comments too
-                if check_ignore_directives(block_content, block_line, &mut ignore_state) {
-                    extract_references_from_text(
-                        path,
-                        block_content,
-                        ByteOffset::from_usize(block_start),
-                        block_line,
-                        &file_code_mask,
-                        reqs,
-                    );
+        while i < bytes.len() {
+            if in_block_comment {
+                if i + 1 < bytes.len() && bytes[i] == b'*' && bytes[i + 1] == b'/' {
+                    let block_content = &content[block_start..i];
+                    if check_ignore_directives(block_content, block_line, &mut ignore_state) {
+                        extract_references_from_text(
+                            path,
+                            block_content,
+                            ByteOffset::from_usize(block_start),
+                            block_line,
+                            &file_code_mask,
+                            reqs,
+                        );
+                    }
+                    in_block_comment = false;
+                    i += 2;
+                    continue;
                 }
-                in_block_comment = false;
+            } else if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+                in_block_comment = true;
+                block_start = i + 2;
+                block_line = line_starts.line_number_for_offset(ByteOffset::from_usize(i));
                 i += 2;
                 continue;
             }
-        } else if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
-            in_block_comment = true;
-            block_start = i + 2;
-            block_line = line_starts.line_number_for_offset(ByteOffset::from_usize(i));
-            i += 2;
-            continue;
+            i += 1;
         }
-        i += 1;
     }
 }
 
@@ -1119,5 +1119,22 @@ pub fn reconnect() {}
         assert_eq!(reqs.len(), 5, "expected 5 references, got: {ids:?}");
         // Refines produces a warning
         assert_eq!(reqs.warnings.len(), 1);
+    }
+
+    #[test]
+    fn test_yaml_only_scans_hash_comments() {
+        // URLs with // must not produce false positives in YAML files.
+        let content = "url: https://example.com/api\n# r[impl yaml.endpoint]\npath: /v1\n";
+        let reqs = Reqs::extract_from_content(Path::new("config.yaml"), content);
+        assert_eq!(reqs.len(), 1, "only the # comment should be extracted");
+        assert_eq!(reqs.references[0].req_id, "yaml.endpoint");
+    }
+
+    #[test]
+    fn test_yaml_block_comment_syntax_not_scanned() {
+        // /* */ is not valid YAML comment syntax; must not be parsed as one.
+        let content = "/* r[impl yaml.false-positive] */\n";
+        let reqs = Reqs::extract_from_content(Path::new("config.yml"), content);
+        assert_eq!(reqs.len(), 0, "/* */ should not be treated as a comment in YAML");
     }
 }

--- a/crates/tracey-core/src/lexer.rs
+++ b/crates/tracey-core/src/lexer.rs
@@ -278,6 +278,35 @@ fn check_ignore_directives(text: &str, line: LineNumber, state: &mut IgnoreState
     true
 }
 
+/// Find the byte position where a YAML line comment starts.
+///
+/// Per the YAML spec a `#` opens a comment only when it is at the start of the
+/// line (possibly after leading whitespace) or is immediately preceded by at
+/// least one whitespace character, AND is not inside a single- or double-quoted
+/// scalar.  A bare `#` embedded in a plain scalar — e.g. `url: http://x/#frag`
+/// — is NOT a comment.
+#[cfg(not(feature = "reverse"))]
+fn find_yaml_comment_start(line: &str) -> Option<usize> {
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut prev: Option<char> = None;
+
+    for (idx, ch) in line.char_indices() {
+        match ch {
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            '#' if !in_single && !in_double => {
+                if idx == 0 || prev.is_some_and(|p| p.is_whitespace()) {
+                    return Some(idx);
+                }
+            }
+            _ => {}
+        }
+        prev = Some(ch);
+    }
+    None
+}
+
 #[cfg(not(feature = "reverse"))]
 fn extract_from_content_text_based(path: &Path, content: &str, reqs: &mut Reqs) {
     // Track line starts for computing line numbers from byte offsets
@@ -302,7 +331,7 @@ fn extract_from_content_text_based(path: &Path, content: &str, reqs: &mut Reqs) 
         if is_yaml {
             // YAML uses # as its only comment syntax; skip // and /* */ scanning
             // entirely to avoid false positives (e.g. URLs containing //).
-            if let Some(comment_pos) = line.find('#') {
+            if let Some(comment_pos) = find_yaml_comment_start(line) {
                 let comment = &line[comment_pos..];
                 let comment_start = line_start.add(comment_pos);
 
@@ -1136,5 +1165,30 @@ pub fn reconnect() {}
         let content = "/* r[impl yaml.false-positive] */\n";
         let reqs = Reqs::extract_from_content(Path::new("config.yml"), content);
         assert_eq!(reqs.len(), 0, "/* */ should not be treated as a comment in YAML");
+    }
+
+    #[test]
+    fn test_yaml_hash_in_scalar_not_parsed() {
+        // '#' embedded in a plain scalar (no preceding whitespace) is not a comment.
+        let content = "url: https://example.com/#frag r[impl should.not.parse]\n";
+        let reqs = Reqs::extract_from_content(Path::new("config.yaml"), content);
+        assert_eq!(reqs.len(), 0, "# inside a scalar value must not be treated as a comment");
+    }
+
+    #[test]
+    fn test_yaml_hash_after_space_is_comment() {
+        // '#' preceded by whitespace is a valid YAML comment.
+        let content = "key: value # r[impl yaml.inline]\n";
+        let reqs = Reqs::extract_from_content(Path::new("config.yaml"), content);
+        assert_eq!(reqs.len(), 1);
+        assert_eq!(reqs.references[0].req_id, "yaml.inline");
+    }
+
+    #[test]
+    fn test_yaml_hash_in_quoted_scalar_not_parsed() {
+        // '#' inside a quoted string is not a comment.
+        let content = "msg: \"hello # r[impl yaml.false-positive]\"\n";
+        let reqs = Reqs::extract_from_content(Path::new("config.yaml"), content);
+        assert_eq!(reqs.len(), 0, "# inside a double-quoted scalar must not be a comment");
     }
 }

--- a/crates/tracey-core/src/lexer.rs
+++ b/crates/tracey-core/src/lexer.rs
@@ -289,6 +289,11 @@ fn extract_from_content_text_based(path: &Path, content: &str, reqs: &mut Reqs) 
 
     let mut ignore_state = IgnoreState::default();
 
+    let is_yaml = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| matches!(e, "yml" | "yaml"));
+
     // Scan for comments and extract references
     for (line_idx, line) in content.lines().enumerate() {
         let line_num = LineNumber::from_zero_based(line_idx);
@@ -309,6 +314,26 @@ fn extract_from_content_text_based(path: &Path, content: &str, reqs: &mut Reqs) 
                     &file_code_mask,
                     reqs,
                 );
+            }
+        }
+
+        // For YAML files, also scan # line comments.
+        // YAML uses # as its only comment syntax; // and /* */ don't apply.
+        if is_yaml {
+            if let Some(comment_pos) = line.find('#') {
+                let comment = &line[comment_pos..];
+                let comment_start = line_start.add(comment_pos);
+
+                if check_ignore_directives(comment, line_num, &mut ignore_state) {
+                    extract_references_from_text(
+                        path,
+                        comment,
+                        comment_start,
+                        line_num,
+                        &file_code_mask,
+                        reqs,
+                    );
+                }
             }
         }
     }

--- a/crates/tracey-core/src/sources.rs
+++ b/crates/tracey-core/src/sources.rs
@@ -508,6 +508,53 @@ mod tests {
     }
 
     #[test]
+    fn test_memory_sources_yaml() {
+        let result = Reqs::extract(
+            MemorySources::new()
+                .add("config.yml", "# r[impl yaml.req.one]")
+                .add(
+                    "pipeline.yaml",
+                    "# r[impl yaml.req.two]\nsteps:\n  - name: build # r[verify yaml.req.three]",
+                ),
+        )
+        .unwrap();
+
+        assert_eq!(result.reqs.len(), 3);
+        assert_eq!(result.reqs.references[0].req_id, "yaml.req.one");
+        assert_eq!(result.reqs.references[1].req_id, "yaml.req.two");
+        assert_eq!(result.reqs.references[2].req_id, "yaml.req.three");
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_memory_sources_yaml_all_verbs() {
+        let content = "# r[impl feat.one]\n# r[verify feat.two]\n# r[depends feat.three]\n# r[related feat.four]\n# r[define feat.five]\n";
+        let result = Reqs::extract(MemorySources::new().add("spec.yml", content)).unwrap();
+
+        assert_eq!(result.reqs.len(), 5);
+        assert_eq!(
+            result.reqs.references[0].verb,
+            crate::lexer::RefVerb::Impl
+        );
+        assert_eq!(
+            result.reqs.references[1].verb,
+            crate::lexer::RefVerb::Verify
+        );
+        assert_eq!(
+            result.reqs.references[2].verb,
+            crate::lexer::RefVerb::Depends
+        );
+        assert_eq!(
+            result.reqs.references[3].verb,
+            crate::lexer::RefVerb::Related
+        );
+        assert_eq!(
+            result.reqs.references[4].verb,
+            crate::lexer::RefVerb::Define
+        );
+    }
+
+    #[test]
     fn test_memory_sources_mixed_languages() {
         let result = Reqs::extract(
             MemorySources::new()

--- a/crates/tracey-core/src/sources.rs
+++ b/crates/tracey-core/src/sources.rs
@@ -583,6 +583,33 @@ mod tests {
         assert!(result.warnings.is_empty());
     }
 
+    #[cfg(feature = "reverse")]
+    #[test]
+    fn test_memory_sources_yaml_reverse() {
+        let result = Reqs::extract(
+            MemorySources::new()
+                .add("config.yml", "# r[impl yaml.one]")
+                .add(
+                    "pipeline.yaml",
+                    "steps:\n  - name: build # r[verify yaml.two]\n",
+                ),
+        )
+        .unwrap();
+
+        assert_eq!(result.reqs.len(), 2);
+        assert_eq!(result.reqs.references[0].req_id, "yaml.one");
+        assert_eq!(
+            result.reqs.references[0].verb,
+            crate::lexer::RefVerb::Impl
+        );
+        assert_eq!(result.reqs.references[1].req_id, "yaml.two");
+        assert_eq!(
+            result.reqs.references[1].verb,
+            crate::lexer::RefVerb::Verify
+        );
+        assert!(result.warnings.is_empty());
+    }
+
     #[test]
     fn test_supported_extensions() {
         use std::ffi::OsStr;

--- a/crates/tracey-core/src/sources.rs
+++ b/crates/tracey-core/src/sources.rs
@@ -81,6 +81,8 @@ pub const SUPPORTED_EXTENSIONS: &[&str] = &[
     "bash",   // Bash
     "zsh",    // Zsh
     "nix",    // Nix
+    "yml",    // YAML
+    "yaml",   // YAML (alternate extension)
 ];
 
 /// Check if a file extension is supported for scanning
@@ -546,6 +548,9 @@ mod tests {
         assert!(is_supported_extension(OsStr::new("go")));
         assert!(is_supported_extension(OsStr::new("php")));
         assert!(is_supported_extension(OsStr::new("nix")));
+
+        assert!(is_supported_extension(OsStr::new("yml")));
+        assert!(is_supported_extension(OsStr::new("yaml")));
 
         assert!(!is_supported_extension(OsStr::new("md")));
         assert!(!is_supported_extension(OsStr::new("txt")));

--- a/crates/tracey-core/src/sources.rs
+++ b/crates/tracey-core/src/sources.rs
@@ -83,6 +83,7 @@ pub const SUPPORTED_EXTENSIONS: &[&str] = &[
     "nix",    // Nix
     "yml",    // YAML
     "yaml",   // YAML (alternate extension)
+    "json5",  // JSON5
 ];
 
 /// Check if a file extension is supported for scanning
@@ -555,6 +556,50 @@ mod tests {
     }
 
     #[test]
+    fn test_memory_sources_json5() {
+        let result = Reqs::extract(
+            MemorySources::new()
+                .add("config.json5", "// r[impl json5.req.one]")
+                .add("settings.json5", "// r[verify json5.req.two]")
+                .add("other.json5", "/* r[impl json5.req.three] */"),
+        )
+        .unwrap();
+
+        assert_eq!(result.reqs.len(), 3);
+        assert_eq!(result.reqs.references[0].req_id, "json5.req.one");
+        assert_eq!(result.reqs.references[1].req_id, "json5.req.two");
+        assert_eq!(result.reqs.references[2].req_id, "json5.req.three");
+        assert!(result.warnings.is_empty());
+    }
+
+    #[cfg(feature = "reverse")]
+    #[test]
+    fn test_memory_sources_json5_reverse() {
+        let result = Reqs::extract(
+            MemorySources::new()
+                .add("config.json5", "// r[impl json5.one]")
+                .add(
+                    "settings.json5",
+                    "{ key: 'value' /* r[verify json5.two] */ }",
+                ),
+        )
+        .unwrap();
+
+        assert_eq!(result.reqs.len(), 2);
+        assert_eq!(result.reqs.references[0].req_id, "json5.one");
+        assert_eq!(
+            result.reqs.references[0].verb,
+            crate::lexer::RefVerb::Impl
+        );
+        assert_eq!(result.reqs.references[1].req_id, "json5.two");
+        assert_eq!(
+            result.reqs.references[1].verb,
+            crate::lexer::RefVerb::Verify
+        );
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
     fn test_memory_sources_mixed_languages() {
         let result = Reqs::extract(
             MemorySources::new()
@@ -625,6 +670,7 @@ mod tests {
 
         assert!(is_supported_extension(OsStr::new("yml")));
         assert!(is_supported_extension(OsStr::new("yaml")));
+        assert!(is_supported_extension(OsStr::new("json5")));
 
         assert!(!is_supported_extension(OsStr::new("md")));
         assert!(!is_supported_extension(OsStr::new("txt")));

--- a/docs/content/guide/annotating-code.md
+++ b/docs/content/guide/annotating-code.md
@@ -128,6 +128,14 @@ Tracey extracts annotations from comments in all major languages via tree-sitter
 /* r[verify buffer.allocation] */
 ```
 
+**YAML** (`.yml`, `.yaml`) — `#` line comments:
+```yaml
+# r[impl pipeline.deploy-step]
+steps:
+  - name: deploy
+    run: ./deploy.sh  # r[verify pipeline.deploy-step]
+```
+
 ## StrictDoc-style markers (`@relation`)
 
 If your spec is authored in [StrictDoc](https://strictdoc.readthedocs.io/) — see [Writing Specs](writing-specs.md#strictdoc-format-sdoc) — tracey also recognises StrictDoc's `@relation(...)` annotation in source comments. The two syntaxes coexist freely; both produce references against the same spec.

--- a/docs/content/guide/annotating-code.md
+++ b/docs/content/guide/annotating-code.md
@@ -136,6 +136,14 @@ steps:
     run: ./deploy.sh  # r[verify pipeline.deploy-step]
 ```
 
+**JSON5** (`.json5`) — `//` and `/* */` comments:
+```json5
+// r[impl config.schema]
+{
+  host: "localhost", /* r[verify config.schema] */
+}
+```
+
 ## StrictDoc-style markers (`@relation`)
 
 If your spec is authored in [StrictDoc](https://strictdoc.readthedocs.io/) — see [Writing Specs](writing-specs.md#strictdoc-format-sdoc) — tracey also recognises StrictDoc's `@relation(...)` annotation in source comments. The two syntaxes coexist freely; both produce references against the same spec.

--- a/docs/content/guide/annotating-code.md
+++ b/docs/content/guide/annotating-code.md
@@ -129,6 +129,7 @@ Tracey extracts annotations from comments in all major languages via tree-sitter
 ```
 
 **YAML** (`.yml`, `.yaml`) — `#` line comments:
+
 ```yaml
 # r[impl pipeline.deploy-step]
 steps:
@@ -137,6 +138,7 @@ steps:
 ```
 
 **JSON5** (`.json5`) — `//` and `/* */` comments:
+
 ```json5
 // r[impl config.schema]
 {

--- a/docs/content/spec/tracey.md
+++ b/docs/content/spec/tracey.md
@@ -269,6 +269,7 @@ Tracey MUST use tree-sitter for parsing source code to extract comments. This en
 > | TypeScript | `.ts`, `.tsx`, `.mts`   | `//`, `/* */`                     |
 > | JavaScript | `.js`, `.jsx`, `.cjs`   | `//`, `/* */`                     |
 > | YAML       | `.yml`, `.yaml`         | `#`                               |
+> | JSON5      | `.json5`                | `//`, `/* */`                     |
 
 > r[ref.parser.unified]
 > The same tree-sitter based extraction MUST be used for both forward traceability (finding which requirements are implemented) and reverse traceability (finding which code units have requirement annotations).

--- a/docs/content/spec/tracey.md
+++ b/docs/content/spec/tracey.md
@@ -268,6 +268,7 @@ Tracey MUST use tree-sitter for parsing source code to extract comments. This en
 > | Python     | `.py`                   | `#`, `""" """`                    |
 > | TypeScript | `.ts`, `.tsx`, `.mts`   | `//`, `/* */`                     |
 > | JavaScript | `.js`, `.jsx`, `.cjs`   | `//`, `/* */`                     |
+> | YAML       | `.yml`, `.yaml`         | `#`                               |
 
 > r[ref.parser.unified]
 > The same tree-sitter based extraction MUST be used for both forward traceability (finding which requirements are implemented) and reverse traceability (finding which code units have requirement annotations).


### PR DESCRIPTION
Adds `r[impl ...]` support for YAML (`*.yaml` and `*.yml`) and JSON5 (`*.json5`) files, so e.g. GitHub workflows, Helm charts, and certain tool configurations can be considered the implementation of requirements.

We needed this feature, so we added it in a fork and have used it for about a week now without problems. The repo that uses our Tracey fork is private so I cannot link to it here though.

Co-authored with Claude, and I am unfamiliar both with Rust in general and the Tracey codebase in particular. So I humbly submit this and welcome feedback 😅 