### PR TITLE
fix: requirement character parsing

### DIFF
--- a/crates/tracey-core/src/code_units.rs
+++ b/crates/tracey-core/src/code_units.rs
@@ -14,6 +14,7 @@
 //! - Code added without updating the spec
 //! - Potential dead code or technical debt
 
+use crate::lexer::is_valid_req_char;
 use crate::positions::{ByteOffset, LineNumber, RefLocation};
 use crate::{RuleId, parse_rule_id};
 use arborium::tree_sitter::{Node, Parser};
@@ -1850,7 +1851,7 @@ fn try_parse_full_ref(
         end_idx = idx;
         if c == ']' || c == ' ' {
             break;
-        } else if c.is_ascii_alphanumeric() || c == '-' || c == '.' || c == '+' {
+        } else if is_valid_req_char(c) {
             first_word.push(c);
             chars.next();
         } else {
@@ -1884,12 +1885,7 @@ fn try_parse_full_ref(
                     if c == ']' {
                         chars.next();
                         break;
-                    } else if c.is_ascii_alphanumeric()
-                        || c == '-'
-                        || c == '_'
-                        || c == '+'
-                        || c == '.'
-                    {
+                    } else if is_valid_req_char(c) {
                         req_id.push(c);
                         chars.next();
                     } else {
@@ -1928,78 +1924,10 @@ fn try_parse_full_ref(
 fn try_parse_req_ref(
     chars: &mut std::iter::Peekable<impl Iterator<Item = (usize, char)>>,
 ) -> Option<RuleId> {
-    // First char must be an ASCII letter. Case is preserved.
-    let first_char = chars.peek().map(|(_, c)| *c)?;
-    if !first_char.is_ascii_alphabetic() {
+    let Some(ParsedFullRef::Parsed { verb: _, req_id, end_idx: _ }) = try_parse_full_ref(chars) else {
         return None;
-    }
-
-    let mut first_word = String::new();
-    first_word.push(first_char);
-    chars.next();
-
-    // Read the first word
-    while let Some(&(_, c)) = chars.peek() {
-        if c == ']' || c == ' ' {
-            break;
-        } else if c.is_ascii_alphanumeric() || c == '-' || c == '.' || c == '+' {
-            first_word.push(c);
-            chars.next();
-        } else {
-            return None;
-        }
-    }
-
-    // Check what follows
-    match chars.peek().map(|(_, c)| *c) {
-        Some(' ') => {
-            // Might be [verb req.id]
-            let verbs = ["impl", "verify", "define", "depends", "related"];
-            if verbs.contains(&first_word.as_str()) {
-                chars.next(); // consume space
-
-                // Read the requirement ID
-                let mut req_id = String::new();
-
-                // First char of rule ID must be an ASCII letter (case preserved).
-                if let Some(&(_, c)) = chars.peek() {
-                    if c.is_ascii_alphabetic() {
-                        req_id.push(c);
-                        chars.next();
-                    } else {
-                        return None;
-                    }
-                }
-
-                while let Some(&(_, c)) = chars.peek() {
-                    if c == ']' {
-                        chars.next();
-                        break;
-                    } else if c.is_ascii_alphanumeric() || c == '-' || c == '+' || c == '.' {
-                        req_id.push(c);
-                        chars.next();
-                    } else {
-                        return None;
-                    }
-                }
-
-                if is_valid_req_id(&req_id) {
-                    return parse_rule_id(&req_id);
-                }
-            }
-            None
-        }
-        Some(']') => {
-            chars.next(); // consume ]
-            // [req.id] format
-            if is_valid_req_id(&first_word) {
-                parse_rule_id(&first_word)
-            } else {
-                None
-            }
-        }
-        _ => None,
-    }
+    };
+    Some(req_id)
 }
 
 fn is_valid_req_id(req_id: &str) -> bool {

--- a/crates/tracey-core/src/lexer.rs
+++ b/crates/tracey-core/src/lexer.rs
@@ -225,6 +225,10 @@ pub(crate) fn extract_from_content(path: &Path, content: &str, reqs: &mut Reqs) 
     }
 }
 
+pub(crate) fn is_valid_req_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' || c == '+'
+}
+
 /// State for tracking ignore directives across lines.
 ///
 /// r[impl ref.ignore.prefix]
@@ -433,7 +437,7 @@ fn extract_references_from_text(
                 while let Some(&(_, c)) = chars.peek() {
                     if c == ']' || c == ' ' {
                         break;
-                    } else if c.is_ascii_alphanumeric() || c == '-' || c == '.' || c == '+' {
+                    } else if is_valid_req_char(c) {
                         first_word.push(c);
                         chars.next();
                     } else {
@@ -476,8 +480,7 @@ fn extract_references_from_text(
                             if c == ']' {
                                 chars.next();
                                 break;
-                            } else if c.is_ascii_alphanumeric() || c == '-' || c == '+' || c == '.'
-                            {
+                            } else if is_valid_req_char(c) {
                                 req_id.push(c);
                                 chars.next();
                             } else {
@@ -687,6 +690,21 @@ mod tests {
         assert_eq!(reqs.len(), 1);
         assert_eq!(reqs.references[0].prefix, "r");
         assert_eq!(reqs.references[0].req_id, "channel.id.allocation");
+        assert_eq!(reqs.references[0].verb, RefVerb::Impl);
+    }
+
+    // r[verify ref.syntax.req-id+3]
+    #[test]
+    fn test_extract_all_valid_req_chars() {
+        let content = r#"
+            // See r[channel0_config.no-reuse] for details
+            fn set_channel0_config() {}
+        "#;
+
+        let reqs = Reqs::extract_from_content(Path::new("test.rs"), content);
+        assert_eq!(reqs.len(), 1);
+        assert_eq!(reqs.references[0].prefix, "r");
+        assert_eq!(reqs.references[0].req_id, "channel0_config.no-reuse");
         assert_eq!(reqs.references[0].verb, RefVerb::Impl);
     }
 


### PR DESCRIPTION
There are a few different places in the code that check the requirement ID, and some of them were missing the underscore (`_`) as a valid character. This change fixes that, and consolidates the logic into a single function. Within `code_units`, I also made `try_parse_req_ref()` just call `try_parse_full_ref()`, as the parsing logic was the same in both.

Great project, by the way!