### PR TITLE
Prepare Tracey 2.0.0-rc.0

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,10 @@
+self-hosted-runner:
+  labels:
+    - bearcove-ubuntu-24.04
+
+paths:
+  .github/workflows/release.yml:
+    ignore:
+      - 'shellcheck reported issue in this script: SC2086:.+'
+      - 'shellcheck reported issue in this script: SC2129:.+'
+      - 'shellcheck reported issue in this script: SC2001:.+'

--- a/.github/build-setup.yml
+++ b/.github/build-setup.yml
@@ -1,11 +1,12 @@
 - name: Setup Rust 1.91
   uses: dtolnay/rust-toolchain@1.91.0
 - name: Setup Node.js
-  uses: actions/setup-node@v4
+  uses: actions/setup-node@v6
   with:
     node-version: "20"
+    package-manager-cache: false
 - name: Setup pnpm
-  uses: pnpm/action-setup@v4
+  uses: pnpm/action-setup@v6
   with:
     version: "9"
 - name: Verify pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: bearcove-ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,21 +14,22 @@ jobs:
   test:
     runs-on: bearcove-ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
+          package-manager-cache: false
 
       - name: Install pnpm
         run: npm install -g pnpm
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,8 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
       - name: Install dist
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
@@ -64,9 +64,9 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.2/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
@@ -82,7 +82,7 @@ jobs:
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -116,7 +116,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
@@ -130,11 +130,12 @@ jobs:
       - name: "Setup Rust 1.91"
         uses: "dtolnay/rust-toolchain@1.91.0"
       - name: "Setup Node.js"
-        uses: "actions/setup-node@v4"
+        uses: "actions/setup-node@v6"
         with:
           "node-version": "20"
+          "package-manager-cache": false
       - name: "Setup pnpm"
-        uses: "pnpm/action-setup@v4"
+        uses: "pnpm/action-setup@v6"
         with:
           "version": "9"
       - name: "Verify pnpm"
@@ -143,7 +144,7 @@ jobs:
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -170,7 +171,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -187,19 +188,19 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -217,7 +218,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-build-global
           path: |
@@ -237,19 +238,19 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -262,14 +263,14 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
           path: dist-manifest.json
       # Create a GitHub Release while uploading all files to it
       - name: "Download GitHub Artifacts"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: artifacts
@@ -302,7 +303,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ on:
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
-    runs-on: "ubuntu-22.04"
+    runs-on: "bearcove-ubuntu-24.04"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
       tag: ${{ !github.event.pull_request && github.ref_name || '' }}
@@ -182,7 +182,7 @@ jobs:
     needs:
       - plan
       - build-local-artifacts
-    runs-on: "ubuntu-22.04"
+    runs-on: "bearcove-ubuntu-24.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
@@ -233,7 +233,7 @@ jobs:
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: "ubuntu-22.04"
+    runs-on: "bearcove-ubuntu-24.04"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
@@ -298,7 +298,7 @@ jobs:
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
     if: ${{ always() && needs.host.result == 'success' }}
-    runs-on: "ubuntu-22.04"
+    runs-on: "bearcove-ubuntu-24.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: bearcove-ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -46,7 +46,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: bearcove-ubuntu-24.04
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: bearcove-ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install ddc
         run: |
@@ -35,10 +35,10 @@ jobs:
         run: cp CNAME docs/public/
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/public
 
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,7 +1043,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.37.3",
  "rustc-demangle",
  "windows-link",
 ]
@@ -1163,6 +1163,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "color-backtrace"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1199,31 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "coolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
+
+[[package]]
+name = "copypatch"
+version = "0.2.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0ab1e265421aabf510f1bba62d4763bb289ffa2d4b7160cfbc522ffbf88223a"
+dependencies = [
+ "libc",
+ "object 0.39.1",
+]
 
 [[package]]
 name = "countme"
@@ -1262,6 +1293,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix 1.1.4",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,6 +1375,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,6 +1447,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1447,16 +1536,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aa60b7d3d49d30f477f9490b7fc3ce42009b5b626b625b0356742884c493a11"
 dependencies = [
  "autocfg",
- "facet-core",
- "facet-macros",
- "facet-reflect",
+ "facet-core 0.44.3",
+ "facet-macros 0.44.3",
+]
+
+[[package]]
+name = "facet"
+version = "0.50.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d43d3564e06baf09ca8ab87072e49e603046af471f1ed68cbeb1ad3ec8fba2"
+dependencies = [
+ "autocfg",
+ "facet-core 0.50.0-rc.0",
+ "facet-macros 0.50.0-rc.0",
+ "facet-reflect 0.50.0-rc.0",
 ]
 
 [[package]]
 name = "facet-axum"
-version = "0.44.0"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f39a1212a72a374f8613d90e9e231935c122b6989cb36e75d4b3c5495f653e"
+checksum = "908be6d9188dfb0404a184582d301d6ef7cb9d4efdd2422b6f950c8b18e34b8f"
 dependencies = [
  "facet-json",
  "facet-urlencoded",
@@ -1464,17 +1564,16 @@ dependencies = [
 
 [[package]]
 name = "facet-cargo-toml"
-version = "0.44.0"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1dfe5ee67dafa3ee39af19b47e0da41337f72e7e0e841f4400dec966b8cafa8"
+checksum = "d4c9695cdf00592365d215d80ad16b48d999d9a5abe35bcc3f3f1e43007cf52c"
 dependencies = [
  "camino",
- "facet",
+ "facet 0.50.0-rc.0",
  "facet-error",
- "facet-format",
- "facet-reflect",
- "facet-toml",
- "facet-value",
+ "facet-reflect 0.50.0-rc.0",
+ "facet-toml 0.50.0-rc.0",
+ "facet-value 0.50.0-rc.0",
 ]
 
 [[package]]
@@ -1484,9 +1583,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11f9ee47507f15c18243a8cba3b2a85b71176173f0097e9164a54dd4e4e3e4ce"
 dependencies = [
  "autocfg",
+ "const-fnv1a-hash",
+ "iddqd 0.3.17",
+ "impls",
+]
+
+[[package]]
+name = "facet-core"
+version = "0.50.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a088a24ab676d6a7ed5ae3a7982a2092cc29684fe4e97b3827d5e239c76d9e79"
+dependencies = [
+ "autocfg",
  "camino",
  "const-fnv1a-hash",
- "iddqd",
+ "iddqd 0.4.2",
  "impls",
  "indexmap",
 ]
@@ -1497,8 +1608,18 @@ version = "0.44.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fb18a3e7ee90139051f679390662ae158439c1564b73b482676b9a3862d13c0"
 dependencies = [
- "facet-core",
- "facet-reflect",
+ "facet-core 0.44.3",
+ "facet-reflect 0.44.3",
+]
+
+[[package]]
+name = "facet-dessert"
+version = "0.50.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93bcd8bfe96797c30bb5cbc7af19854bc793bcc29e884f3caea55ab4d0a76cf2"
+dependencies = [
+ "facet-core 0.50.0-rc.0",
+ "facet-reflect 0.50.0-rc.0",
 ]
 
 [[package]]
@@ -1507,9 +1628,9 @@ version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38cdfbea280cf7e0adcbbf40cff7b9fbfae1148a8e11b4fd4adb99e98a9aa53"
 dependencies = [
- "facet-core",
- "facet-dessert",
- "facet-reflect",
+ "facet-core 0.44.3",
+ "facet-dessert 0.44.5",
+ "facet-reflect 0.44.3",
  "facet-singularize",
  "heck",
  "owo-colors",
@@ -1517,11 +1638,11 @@ dependencies = [
 
 [[package]]
 name = "facet-error"
-version = "0.44.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ad09f4efc4d87eaa1122dbd194caac256ce0c4002b799ffe3f346cdc1ad01"
+checksum = "ccffb10fb21b3efe6c50ec1e66ac9a6e5646176d06a8af24bfabd32223f0fe5e"
 dependencies = [
- "facet",
+ "facet 0.50.0-rc.0",
 ]
 
 [[package]]
@@ -1530,27 +1651,39 @@ version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50e9bca089d254ef30bcb902566f7f8477b29a11cda26d5332bd584259af451c"
 dependencies = [
- "facet-core",
- "facet-dessert",
- "facet-path",
- "facet-reflect",
- "facet-solver",
+ "facet-core 0.44.3",
+ "facet-dessert 0.44.5",
+ "facet-path 0.44.3",
+ "facet-reflect 0.44.3",
+ "facet-solver 0.44.3",
+]
+
+[[package]]
+name = "facet-format"
+version = "0.50.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9f89149e4d373016b1e9f263ce5f9e2171a432163badc3353cfbe3c8a5960f"
+dependencies = [
+ "facet-core 0.50.0-rc.0",
+ "facet-dessert 0.50.0-rc.0",
+ "facet-path 0.50.0-rc.0",
+ "facet-reflect 0.50.0-rc.0",
+ "facet-solver 0.50.0-rc.0",
 ]
 
 [[package]]
 name = "facet-json"
-version = "0.44.6"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dc7a1b6408721dfef48541539b8958a43940bcad5f312f9a691ee3f5ff44465"
+checksum = "e4a49a07dd025d269cf0f5b63679d08d2d9ddd080a578bbe3ec58e414ede1bd5"
 dependencies = [
  "axum-core",
- "facet",
- "facet-core",
- "facet-format",
- "facet-reflect",
+ "facet 0.50.0-rc.0",
+ "facet-core 0.50.0-rc.0",
+ "facet-format 0.50.0-rc.0",
+ "facet-reflect 0.50.0-rc.0",
  "http",
  "http-body-util",
- "memchr",
  "mime",
 ]
 
@@ -1560,7 +1693,18 @@ version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e77becc35b3b3008e7b3ef23356954e46561177316aff0a92c73fc6ddb2a15a0"
 dependencies = [
- "facet-macro-types",
+ "facet-macro-types 0.44.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "facet-macro-parse"
+version = "0.50.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a85e100b892473cef064ca8f3443af4c8eb78b8609eb3224eba8df679caf690"
+dependencies = [
+ "facet-macro-types 0.50.0-rc.0",
  "proc-macro2",
  "quote",
 ]
@@ -1577,12 +1721,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-macro-types"
+version = "0.50.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87b2552407f6f584187a808bd4fbb56f002cc5451454294898276881c232d07a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unsynn",
+]
+
+[[package]]
 name = "facet-macros"
 version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3a7015e119aa043740dc8aee6b1b70e26b6616e1701b329496bf04990f44133"
 dependencies = [
- "facet-macros-impl",
+ "facet-macros-impl 0.44.3",
+]
+
+[[package]]
+name = "facet-macros"
+version = "0.50.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b77f92b6fe3ae6d45544e50351a9a54f7190240220b283916cbcca20a849812b"
+dependencies = [
+ "facet-macros-impl 0.50.0-rc.0",
 ]
 
 [[package]]
@@ -1591,8 +1755,22 @@ version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbb5e6f6cc64210ab12aa625b014db78d34d6a3b63d1011382c141518a1e1f78"
 dependencies = [
- "facet-macro-parse",
- "facet-macro-types",
+ "facet-macro-parse 0.44.3",
+ "facet-macro-types 0.44.3",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "unsynn",
+]
+
+[[package]]
+name = "facet-macros-impl"
+version = "0.50.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1f0535febaea47d61f5386a6e0ab3249a5aaf813ae67e25bf285e97c481e30"
+dependencies = [
+ "facet-macro-parse 0.50.0-rc.0",
+ "facet-macro-types 0.50.0-rc.0",
  "proc-macro2",
  "quote",
  "strsim",
@@ -1605,33 +1783,28 @@ version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e7b83cb0de7c00d6e76f08d36b047d6cb9efc39e10744dbcf7a4a5a19c4903"
 dependencies = [
- "facet-core",
+ "facet-core 0.44.3",
 ]
 
 [[package]]
-name = "facet-postcard"
-version = "0.44.6"
+name = "facet-path"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c903b79cc89428f035e2d010a2d2d5046e08856f5b1360733c2a44b7830d4a33"
+checksum = "4f0aeceb55a22d6ddb1d9d2af4a6223114ce6869821c0ae1091a3c955d1492a7"
 dependencies = [
- "camino",
- "facet-core",
- "facet-format",
- "facet-path",
- "facet-reflect",
- "facet-value",
- "tracing",
+ "facet-core 0.50.0-rc.0",
 ]
 
 [[package]]
 name = "facet-pretty"
-version = "0.44.4"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b93416595a402722978717593f38b3d51ab17b5cc1d914305b1758f02651ead"
+checksum = "c2522ca631c6c71803ecc836d70d0def6db0eb9358bcc39fdbe5ffd44c914e2e"
 dependencies = [
- "facet-core",
- "facet-reflect",
+ "facet-core 0.50.0-rc.0",
+ "facet-reflect 0.50.0-rc.0",
  "owo-colors",
+ "terminal-light",
 ]
 
 [[package]]
@@ -1640,9 +1813,22 @@ version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9cc255bd928399489868fdddec09e69073d622432cc2b52cfa3c3a5d811305c"
 dependencies = [
- "facet-core",
- "facet-path",
+ "facet-core 0.44.3",
+ "facet-path 0.44.3",
  "hashbrown 0.16.1",
+ "regex",
+ "smallvec 2.0.0-alpha.12",
+]
+
+[[package]]
+name = "facet-reflect"
+version = "0.50.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8287a68023eec4152a4d4cb88814e10d38ff6f116cbb70acb4eb58a304f624c6"
+dependencies = [
+ "facet-core 0.50.0-rc.0",
+ "facet-path 0.50.0-rc.0",
+ "hashbrown 0.17.0",
  "regex",
  "smallvec 2.0.0-alpha.12",
 ]
@@ -1659,22 +1845,33 @@ version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4d2427360875510d60267f4bb132f47aa4f5714896be9ca11c516f14542118d"
 dependencies = [
- "facet-core",
- "facet-reflect",
+ "facet-core 0.44.3",
+ "facet-reflect 0.44.3",
+ "strsim",
+]
+
+[[package]]
+name = "facet-solver"
+version = "0.50.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d5bfeaa1e0dcbdfccf86b6f64e258b4d2db839b1573f0bbff8ee27a45a9fbc"
+dependencies = [
+ "facet-core 0.50.0-rc.0",
+ "facet-reflect 0.50.0-rc.0",
  "strsim",
 ]
 
 [[package]]
 name = "facet-styx"
-version = "2.0.0"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94c9458d6d474e5578d3e4aa178c2a61c9d2676bba59dd5686dcd708fe424ab2"
+checksum = "ff3ffef3655f677ccb28e56d4e592a6677063305d9cd4a0369d47df00b2f2445"
 dependencies = [
  "ariadne",
- "facet",
- "facet-core",
- "facet-format",
- "facet-reflect",
+ "facet 0.50.0-rc.0",
+ "facet-core 0.50.0-rc.0",
+ "facet-format 0.50.0-rc.0",
+ "facet-reflect 0.50.0-rc.0",
  "serde_json",
  "styx-format",
  "styx-parse",
@@ -1687,15 +1884,15 @@ version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f373ce237f5585a3bc2d2383e63e2dde8ce12d272ee5f8dfe79d4ec4270042bd"
 dependencies = [
- "facet",
+ "facet 0.44.3",
  "facet-xml",
 ]
 
 [[package]]
 name = "facet-testhelpers"
-version = "0.44.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9003d5bede62269bdc9d71708ab5c686e590a2d20aeb2efa1ba7c49e43651c9a"
+checksum = "253b2adcb0cb610edf9427c5c1fc39623f54bfefb45573bc392c3cf19d4220c4"
 dependencies = [
  "color-backtrace",
  "facet-testhelpers-macros",
@@ -1706,9 +1903,9 @@ dependencies = [
 
 [[package]]
 name = "facet-testhelpers-macros"
-version = "0.44.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6e17dfa5fc4da066dbf46244a72e4e3233c901914b8d979f12a3967649b859"
+checksum = "039a2e061fa36aa598f5f2e8abcd325945a2aed7a0f338772f08fd022defa120"
 dependencies = [
  "quote",
  "unsynn",
@@ -1720,30 +1917,42 @@ version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0da230f77d4c948580af7ee7d8c035c15bf1a22deb38ca5eb164c1d104e970b"
 dependencies = [
- "facet-core",
- "facet-format",
- "facet-reflect",
+ "facet-core 0.44.3",
+ "facet-format 0.44.6",
+ "facet-reflect 0.44.3",
+ "toml_parser",
+]
+
+[[package]]
+name = "facet-toml"
+version = "0.50.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f7a7a88e9a27921bd870700681d450ab7c4bc8a2d1cd69dc2be1d36d5289a6"
+dependencies = [
+ "facet-core 0.50.0-rc.0",
+ "facet-format 0.50.0-rc.0",
+ "facet-reflect 0.50.0-rc.0",
  "toml_parser",
 ]
 
 [[package]]
 name = "facet-typescript"
-version = "0.44.5"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4919638a443495084cad99872ee616d8ad364681fdad56a433a3054d66741821"
+checksum = "6a703417af3a0826bc22d4d5b526ddefb188bb9616ebb5105cacca1b782dcdd5"
 dependencies = [
- "facet-core",
+ "facet-core 0.50.0-rc.0",
 ]
 
 [[package]]
 name = "facet-urlencoded"
-version = "0.44.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3113405d198ea170aeab0e0f2874aa0a689c1107c1c80d6fdf8f408c4f775e50"
+checksum = "70ec7269e8a6a02aba208cfaef9310401fec06e37338ed960def9994510442d2"
 dependencies = [
  "axum-core",
- "facet-core",
- "facet-reflect",
+ "facet-core 0.50.0-rc.0",
+ "facet-reflect 0.50.0-rc.0",
  "form_urlencoded",
  "http",
  "http-body-util",
@@ -1756,9 +1965,21 @@ version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af6a6e316fa579d1058202829960da995a154daab5e2d9f8f770a979d54ee271"
 dependencies = [
- "facet-core",
- "facet-format",
- "facet-reflect",
+ "facet-core 0.44.3",
+ "facet-format 0.44.6",
+ "facet-reflect 0.44.3",
+ "indexmap",
+]
+
+[[package]]
+name = "facet-value"
+version = "0.50.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01766190652de0ce73460cf68addaf6dc4180e0f84363f0a419f5645bc03aca8"
+dependencies = [
+ "facet-core 0.50.0-rc.0",
+ "facet-format 0.50.0-rc.0",
+ "facet-reflect 0.50.0-rc.0",
  "indexmap",
 ]
 
@@ -1768,10 +1989,10 @@ version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f621d4820476340d8dae6bfe49a9ebb16018c79eb303814459dc1ad9ac1eccbf"
 dependencies = [
- "facet",
- "facet-core",
+ "facet 0.44.3",
+ "facet-core 0.44.3",
  "facet-dom",
- "facet-reflect",
+ "facet-reflect 0.44.3",
  "quick-xml",
 ]
 
@@ -1781,10 +2002,10 @@ version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0b8adae3ac1f7159bfdb58bf110a8ddd9cfce4835d86556897210e4fb048bf0"
 dependencies = [
- "facet",
- "facet-core",
- "facet-format",
- "facet-reflect",
+ "facet 0.44.3",
+ "facet-core 0.44.3",
+ "facet-format 0.44.6",
+ "facet-reflect 0.44.3",
  "saphyr-parser",
 ]
 
@@ -1802,19 +2023,19 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "figue"
-version = "2.0.1"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ffdb761cf6aa5298efdef8ae22dac4057d492f85e1e7434864eb1ccbcfeae5"
+checksum = "0f15cb1b43988022a0ad86ae6d0a1cfc67eee47ed289e484aab4f00d452a4215"
 dependencies = [
  "ariadne",
  "camino",
- "facet",
- "facet-core",
+ "facet 0.50.0-rc.0",
+ "facet-core 0.50.0-rc.0",
  "facet-error",
- "facet-format",
+ "facet-format 0.50.0-rc.0",
  "facet-json",
  "facet-pretty",
- "facet-reflect",
+ "facet-reflect 0.50.0-rc.0",
  "figue-attrs",
  "heck",
  "indexmap",
@@ -1828,11 +2049,11 @@ dependencies = [
 
 [[package]]
 name = "figue-attrs"
-version = "2.0.1"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95509cd6139af9c281d9e4f163db7fce0da7101102ac555e677937248437e58"
+checksum = "40742075017ee2bcabe56af40086723107a1f35c69b3f5b00e811d6e96fb3ec2"
 dependencies = [
- "facet",
+ "facet 0.50.0-rc.0",
 ]
 
 [[package]]
@@ -1840,6 +2061,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -2012,11 +2243,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2026,10 +2255,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2113,6 +2344,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -2326,6 +2562,18 @@ dependencies = [
  "foldhash 0.2.0",
  "hashbrown 0.16.1",
  "rustc-hash 2.1.2",
+]
+
+[[package]]
+name = "iddqd"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7721c885a97a7c67bc8645958710f3f43b5e7ad8644ce6f43b188a77f05fda7"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2581,6 +2829,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2634,9 +2888,9 @@ checksum = "18d4ac04a6da2cfd142aee2a057bebeeaa69ea3a30dfd792673361956052cf79"
 dependencies = [
  "aasvg",
  "arborium",
- "facet",
- "facet-toml",
- "facet-value",
+ "facet 0.44.3",
+ "facet-toml 0.44.6",
+ "facet-value 0.44.6",
  "facet-yaml",
  "pikru",
  "pulldown-cmark",
@@ -2704,6 +2958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2720,9 +2975,9 @@ dependencies = [
 
 [[package]]
 name = "moire"
-version = "1.0.0"
+version = "2.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac52dcc0ff5b4710a66626370b1bf85ba3d924fd8019e8cfa100e8dafffda4ad"
+checksum = "fe357ecd78fc5dbb38df1b975ed5542908a40629f9cbdccf1c8130bd03ee509c"
 dependencies = [
  "moire-macros-noop",
  "moire-tokio",
@@ -2731,20 +2986,20 @@ dependencies = [
 
 [[package]]
 name = "moire-macros-noop"
-version = "1.0.0"
+version = "2.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ccdc0bf403f5ecf29c09e8e9f178caed89a914ea032e0c2d99d3824b78892d"
+checksum = "96fbfad00504253bac67fe1b8074f7bbd6a9fcacf63472a63a2e8d7ccdec19d7"
 
 [[package]]
 name = "moire-runtime"
-version = "1.0.0"
+version = "2.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568cc05b223c4c76247467e3bdaa7862f05c38d5c8f6e44198613880f90ecd98"
+checksum = "beed9184c655e7f5c11e657aff9a36ab2870e30417a0e29a3ac861d04006315c"
 dependencies = [
  "ctor",
- "facet",
+ "facet 0.50.0-rc.0",
  "facet-json",
- "facet-value",
+ "facet-value 0.50.0-rc.0",
  "moire-trace-capture",
  "moire-trace-types",
  "moire-types",
@@ -2754,11 +3009,10 @@ dependencies = [
 
 [[package]]
 name = "moire-tokio"
-version = "1.0.0"
+version = "2.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb30c43038ce71c727da5a4ff01d09dd4c823486cc17b3b08661420d0ceda43"
+checksum = "7578183f76b792a6c9c165b11ae7b9e5c69220c19ef1373655596754e9ece6f4"
 dependencies = [
- "ctor",
  "moire-runtime",
  "moire-types",
  "parking_lot",
@@ -2767,9 +3021,9 @@ dependencies = [
 
 [[package]]
 name = "moire-trace-capture"
-version = "1.0.0"
+version = "2.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6685ebbdee1253529c9074c41d8288504b640ffe8c21176ce464fef5c5c00c38"
+checksum = "86d8a9ed465e7c9b52cd90445974c568684e31784793a0654eb9a4a22739be87"
 dependencies = [
  "libc",
  "moire-trace-types",
@@ -2777,29 +3031,29 @@ dependencies = [
 
 [[package]]
 name = "moire-trace-types"
-version = "1.0.0"
+version = "2.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ef6f98b447211257a517d101f0f5cf4300627cd6fd1c0c13ff53d157a872c9d"
+checksum = "0ae2abde8ed990d31da5b4ecd8920240e2dd0832cafce5f41cafcad9e5d8e57a"
 dependencies = [
- "facet",
+ "facet 0.50.0-rc.0",
 ]
 
 [[package]]
 name = "moire-types"
-version = "1.0.0"
+version = "2.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667b2fc41e30d3b0f7d0d29e978d3f473afaf0e0be355202eead317e35ace200"
+checksum = "8c4d5dc2b09ad7aed54b8022db1a7a76f2264e8328f62ca24661a0d26a6bfadf"
 dependencies = [
- "facet",
- "facet-value",
+ "facet 0.50.0-rc.0",
+ "facet-value 0.50.0-rc.0",
  "moire-trace-types",
 ]
 
 [[package]]
 name = "moire-wasm"
-version = "1.0.0"
+version = "2.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f143cef34407271acdbca3af106d82b330693e0990ef87df146441392d8a9577"
+checksum = "56243032be8586da90784087877917bc337e6b0cea72c0a0b4ca496045920564"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2813,11 +3067,11 @@ dependencies = [
 
 [[package]]
 name = "moire-wire"
-version = "1.0.0"
+version = "2.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0ec84eeb2e23a83339cf5edc9d5a3a9ec5849416bd4051951fba416ea3e0f7"
+checksum = "0d10e39253dfb2b27ded818613570cdc6e598d80c3f9078bcc8d142c5ebe99a2"
 dependencies = [
- "facet",
+ "facet 0.50.0-rc.0",
  "facet-json",
  "moire-trace-types",
  "moire-types",
@@ -2834,6 +3088,18 @@ name = "mutants"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nom"
@@ -2926,6 +3192,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "flate2",
+ "memchr",
+ "ruzstd",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3003,6 +3280,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "passfd"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b332c50e4d07c0011fff51ea305374408319908908bc1dbed7a0ffaaf63a8151"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3058,6 +3344,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "phon"
+version = "0.2.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d8793b1b5cbf59a3cfc4aeb2f91e4185ec7e312dc81588df47ce7af6a0f5dc"
+dependencies = [
+ "facet 0.50.0-rc.0",
+ "facet-value 0.50.0-rc.0",
+ "phon-engine",
+ "phon-ir",
+ "phon-jit",
+ "phon-schema",
+]
+
+[[package]]
+name = "phon-engine"
+version = "0.2.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3680c6188f79a6e2383bfa30ba5e8ba607ecf93dd8d06b663c931a4e38642e0"
+dependencies = [
+ "facet-value 0.50.0-rc.0",
+ "phon-ir",
+ "phon-schema",
+]
+
+[[package]]
+name = "phon-ir"
+version = "0.2.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5f17d081ab2b92b45c97e221a8b83d854ab1aeef5996ec5f41e0b0c7e7e7b8"
+dependencies = [
+ "phon-schema",
+]
+
+[[package]]
+name = "phon-jit"
+version = "0.2.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245378b81f03900cf32f6f74e7d481c6e6695134843b2075b0e297c043acb255"
+dependencies = [
+ "copypatch",
+ "phon-ir",
+ "phon-schema",
+]
+
+[[package]]
+name = "phon-schema"
+version = "0.2.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8cbe35ada29454b29d608a27fe05935d6c1e0adf50354cc807f093a2b3318c"
+dependencies = [
+ "blake3",
+ "facet-value 0.50.0-rc.0",
+]
+
+[[package]]
 name = "pikru"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3097,6 +3438,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -3341,125 +3688,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "roam"
-version = "7.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb8134b18b8735b239996b748307cfb208d84c245ed5595a6c2eece0e3c819a5"
-dependencies = [
- "facet",
- "facet-postcard",
- "roam-core",
- "roam-hash",
- "roam-service-macros",
- "roam-types",
-]
-
-[[package]]
-name = "roam-core"
-version = "7.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736e8d8279a37ddce65b165ebd4c665b254885a159c75ff20b9379bff3d92626"
-dependencies = [
- "facet",
- "facet-core",
- "facet-error",
- "facet-format",
- "facet-postcard",
- "facet-reflect",
- "getrandom 0.3.4",
- "moire",
- "roam-types",
- "smallvec 1.15.1",
- "tokio",
- "tracing",
- "wasm-bindgen-futures",
- "zerocopy",
-]
-
-[[package]]
-name = "roam-hash"
-version = "7.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926fac2289cbccf6100dd9fa733001a2999651cdeb6bea064320bac185dfa817"
-dependencies = [
- "blake3",
- "facet-core",
- "heck",
- "roam-types",
-]
-
-[[package]]
-name = "roam-local"
-version = "7.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6740aab5a0574d25325edf08fe898470c3d888a814a6e253e37ffa200ec4d2e0"
-dependencies = [
- "moire",
- "tokio",
-]
-
-[[package]]
-name = "roam-macros-core"
-version = "7.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f5ac50c8954493d007a2a5541753fba33c605955abeb9221568ba0d160219e9"
-dependencies = [
- "facet-cargo-toml",
- "heck",
- "proc-macro2",
- "quote",
- "roam-macros-parse",
-]
-
-[[package]]
-name = "roam-macros-parse"
-version = "7.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a453d67c29e4f4f34abdf0dbf56f2fce8f7e3fdbb2640df077237ac375cd866d"
-dependencies = [
- "proc-macro2",
- "unsynn",
-]
-
-[[package]]
-name = "roam-service-macros"
-version = "7.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769c26280491ff451c3c7ac14ed7034237ae0e586d5d08297c4d43e9bea00797"
-dependencies = [
- "proc-macro2",
- "roam-macros-core",
-]
-
-[[package]]
-name = "roam-stream"
-version = "7.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0751a9582404ea88c9eacbc679aefe2581a1e4867d384058c835ccd14ba32165"
-dependencies = [
- "moire",
- "roam-types",
- "tokio",
-]
-
-[[package]]
-name = "roam-types"
-version = "7.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2c23550c346311389eea924816f06e7ed3a049d8bb437609ece1a312cabc67"
-dependencies = [
- "bitflags 2.11.0",
- "facet",
- "facet-core",
- "facet-path",
- "facet-postcard",
- "futures-channel",
- "smallvec 1.15.1",
- "structstruck",
- "tokio",
-]
-
-[[package]]
 name = "rowan"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3563,6 +3791,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3593,6 +3830,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ruzstd"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "ryu"
@@ -3766,6 +4012,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3774,6 +4041,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -3858,9 +4131,9 @@ dependencies = [
 
 [[package]]
 name = "styx-cst"
-version = "2.0.0"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ecab1fb549ab2a0cc52b969b489cd0dd5e6968fa1e16bf965409e4103e921ce"
+checksum = "c083df3ad61b4fc1382301c120496bd1ed56506676cfe825875adc5a3f97d517"
 dependencies = [
  "rowan",
  "styx-tokenizer",
@@ -3868,9 +4141,9 @@ dependencies = [
 
 [[package]]
 name = "styx-embed"
-version = "2.0.0"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf85e3ff1d44aa88d132f95d6dcfa696d083c41e6496dd977c9c63dc1660e3"
+checksum = "5cd6ba7fd562556fd0c5ecc6e6454da2254607d47e0fb15ba3b5a43df71daae9"
 dependencies = [
  "blake3",
  "goblin",
@@ -3881,9 +4154,9 @@ dependencies = [
 
 [[package]]
 name = "styx-embed-macros"
-version = "2.0.0"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f44c7f52a37363f9ee14773c74757d43bdc876dfb5f2b0cac98c5f96104734"
+checksum = "73ced98d60c69c754b04d394741b4bd73271414cbcb31b667203c1b0f77335e0"
 dependencies = [
  "blake3",
  "lz4_flex",
@@ -3894,9 +4167,9 @@ dependencies = [
 
 [[package]]
 name = "styx-format"
-version = "2.0.0"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed35156a5b5ecb552495b225a57e7790142a0fce9bc8b3274b599d709c6da58"
+checksum = "0cc4e3ca638eb766a3f21a63e69f5f3d87d93e26dbd5c082f5ac05668b8cc83e"
 dependencies = [
  "styx-cst",
  "styx-parse",
@@ -3905,9 +4178,9 @@ dependencies = [
 
 [[package]]
 name = "styx-parse"
-version = "2.0.0"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c738428c4d09db9fc578cfb22357b0ddb19cb614ed2a0811856c9c8ed4be0d7"
+checksum = "d92cfbe2d66c59fd7c524553958b229d5aca7779be3016f6d075ebe9c7b8ab33"
 dependencies = [
  "styx-tokenizer",
  "tracing",
@@ -3915,18 +4188,18 @@ dependencies = [
 
 [[package]]
 name = "styx-tokenizer"
-version = "2.0.0"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751728b08f449d291f80c8f084c4f4c6268c543d41f7e8d85c70b092bcea9388"
+checksum = "ef0423fc2681ac5202f313c2ae7b7ea6002daad840a59af4a9a65794c822b333"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "styx-tree"
-version = "2.0.0"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75454a260a6dd281de9c387179f746026358b465e0604db7b35aadc38404f01"
+checksum = "42ab9830b645a9bf2e0b1e25e57d0399dfefc81fafee26e37036b7aaa644b8a2"
 dependencies = [
  "ariadne",
  "facet-testhelpers",
@@ -4141,6 +4414,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal-light"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6f76be906d875a0ce764c52a055858c24847cb7dc674d3a5ad8cf7e3dd4ee9f"
+dependencies = [
+ "coolor",
+ "crossterm",
+ "thiserror 1.0.69",
+ "xterm-query",
 ]
 
 [[package]]
@@ -4406,7 +4691,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracey"
-version = "1.4.0"
+version = "2.0.0-rc.0"
 dependencies = [
  "arborium",
  "async-trait",
@@ -4414,7 +4699,7 @@ dependencies = [
  "blake3",
  "dirs",
  "eyre",
- "facet",
+ "facet 0.50.0-rc.0",
  "facet-axum",
  "facet-error",
  "facet-json",
@@ -4430,10 +4715,6 @@ dependencies = [
  "notify",
  "open",
  "owo-colors",
- "roam",
- "roam-core",
- "roam-local",
- "roam-stream",
  "rust-mcp-sdk",
  "serde",
  "serde_json",
@@ -4455,27 +4736,28 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "urlencoding",
+ "vox",
  "walkdir",
 ]
 
 [[package]]
 name = "tracey-api"
-version = "1.4.0"
+version = "2.0.0-rc.0"
 dependencies = [
- "facet",
+ "facet 0.50.0-rc.0",
  "tracey-core",
 ]
 
 [[package]]
 name = "tracey-config"
-version = "1.4.0"
+version = "2.0.0-rc.0"
 dependencies = [
- "facet",
+ "facet 0.50.0-rc.0",
 ]
 
 [[package]]
 name = "tracey-core"
-version = "1.4.0"
+version = "2.0.0-rc.0"
 dependencies = [
  "arborium",
  "arborium-asm",
@@ -4510,7 +4792,7 @@ dependencies = [
  "arborium-typescript",
  "arborium-vb",
  "eyre",
- "facet",
+ "facet 0.50.0-rc.0",
  "globset",
  "ignore",
  "marq",
@@ -4521,12 +4803,13 @@ dependencies = [
 
 [[package]]
 name = "tracey-proto"
-version = "1.4.0"
+version = "2.0.0-rc.0"
 dependencies = [
- "facet",
- "roam",
+ "facet 0.50.0-rc.0",
  "tracey-api",
  "tracey-core",
+ "vox",
+ "vox-schema",
 ]
 
 [[package]]
@@ -4661,6 +4944,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4753,6 +5042,160 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vox"
+version = "0.9.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f325d36d8805994408c8ffcd322d26b3a3ae436b5becee80df627b71ffbff77"
+dependencies = [
+ "facet 0.50.0-rc.0",
+ "facet-pretty",
+ "facet-reflect 0.50.0-rc.0",
+ "moire",
+ "tokio",
+ "tracing",
+ "vox-core",
+ "vox-phon",
+ "vox-service-macros",
+ "vox-stream",
+ "vox-types",
+]
+
+[[package]]
+name = "vox-core"
+version = "0.9.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae4b34aad4ad8945fe421a17fdae95c6956cab9e9e4d64965f194a12f9b79d5"
+dependencies = [
+ "facet 0.50.0-rc.0",
+ "facet-core 0.50.0-rc.0",
+ "facet-error",
+ "facet-reflect 0.50.0-rc.0",
+ "futures-util",
+ "getrandom 0.4.2",
+ "moire",
+ "smallvec 1.15.1",
+ "tokio",
+ "tracing",
+ "vox-phon",
+ "vox-types",
+ "wasm-bindgen-futures",
+ "zerocopy",
+]
+
+[[package]]
+name = "vox-fdpass"
+version = "0.9.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f0f143096bd02bb1a15b52b4be845b6719cf8051cdc0b21e5c56dc9b612769"
+dependencies = [
+ "libc",
+ "passfd",
+ "tokio",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "vox-macros-core"
+version = "0.9.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2c8115864699eada212fd688a6d474507605af576806d1dd6a14cc92f0752ae"
+dependencies = [
+ "facet-cargo-toml",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "vox-macros-parse",
+]
+
+[[package]]
+name = "vox-macros-parse"
+version = "0.9.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a51100078d3419f7976c98b056367396da0a4c7ef3f49b0c7c90f3acbdc9cd99"
+dependencies = [
+ "proc-macro2",
+ "unsynn",
+]
+
+[[package]]
+name = "vox-phon"
+version = "0.9.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9debebc0fb9bd59bf2b6d599995dbbf36ead5ce93347c1d2b5508acc3d2f26c1"
+dependencies = [
+ "facet 0.50.0-rc.0",
+ "moire",
+ "phon",
+ "phon-engine",
+ "phon-ir",
+ "phon-jit",
+ "phon-schema",
+]
+
+[[package]]
+name = "vox-schema"
+version = "0.9.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41be020ed900f6ce8a02e34d33b96bba186e574c5e88f75d89b430703701f8b2"
+dependencies = [
+ "blake3",
+ "facet 0.50.0-rc.0",
+ "facet-core 0.50.0-rc.0",
+ "indexmap",
+]
+
+[[package]]
+name = "vox-service-macros"
+version = "0.9.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33dd4f2f98c4609e90a5dc0f9c52ab0074e07586be8a9bb595c2cccb3b47ce65"
+dependencies = [
+ "proc-macro2",
+ "vox-macros-core",
+]
+
+[[package]]
+name = "vox-stream"
+version = "0.9.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d699bc378cc88f8086116631010fef82c938b69bd12d0c2fb3131435b7db0fd5"
+dependencies = [
+ "libc",
+ "moire",
+ "tokio",
+ "tracing",
+ "vox-core",
+ "vox-fdpass",
+ "vox-types",
+]
+
+[[package]]
+name = "vox-types"
+version = "0.9.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f20e84f1c186e4b847648093c7bdd96328bcf501146fe06859594415ecee969"
+dependencies = [
+ "bitflags 2.11.0",
+ "blake3",
+ "bytes",
+ "facet 0.50.0-rc.0",
+ "facet-core 0.50.0-rc.0",
+ "facet-path 0.50.0-rc.0",
+ "facet-reflect 0.50.0-rc.0",
+ "facet-value 0.50.0-rc.0",
+ "futures-channel",
+ "heck",
+ "indexmap",
+ "moire",
+ "smallvec 1.15.1",
+ "structstruck",
+ "tokio",
+ "vox-phon",
+ "vox-schema",
+ "wasmtimer",
+]
 
 [[package]]
 name = "vte"
@@ -4893,6 +5336,19 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5209,7 +5665,17 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "1.4.0"
+version = "2.0.0-rc.0"
+
+[[package]]
+name = "xterm-query"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "292c33df434fde4ecd87a7afecdfa1681a3d29567fc69c774a0d83d32c095331"
+dependencies = [
+ "nix",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 ignored = ["facet-error"]
 
 [workspace.package]
-version = "1.4.0"
+version = "2.0.0-rc.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bearcove/tracey"
@@ -15,23 +15,23 @@ authors = ["Amos Wenger <amos@bearcove.eu>"]
 
 [workspace.dependencies]
 # Internal
-tracey-core = { path = "crates/tracey-core", version = "1.4.0", default-features = false }
-tracey-api = { path = "crates/tracey-api", version = "1.4.0" }
-tracey-proto = { path = "crates/tracey-proto", version = "1.4.0" }
-tracey-config = { path = "crates/tracey-config", version = "1.4.0" }
+tracey-core = { path = "crates/tracey-core", version = "2.0.0-rc.0", default-features = false }
+tracey-api = { path = "crates/tracey-api", version = "2.0.0-rc.0" }
+tracey-proto = { path = "crates/tracey-proto", version = "2.0.0-rc.0" }
+tracey-config = { path = "crates/tracey-config", version = "2.0.0-rc.0" }
 
 # Facet ecosystem
-facet = { version = "0.44" }
-facet-axum = { version = "0.44" }
-facet-styx = { version = "2.0.0" }
-facet-json = { version = "0.44" }
-facet-error = { version = "0.44" }
+facet = { version = "0.50.0-rc.0" }
+facet-axum = { version = "0.50.0-rc.0" }
+facet-styx = { version = "5.0.0-rc.0" }
+facet-json = { version = "0.50.0-rc.0" }
+facet-error = { version = "0.50.0-rc.0" }
 
 # Styx
-styx-embed = { version = "2.0.0" }
+styx-embed = { version = "5.0.0-rc.0" }
 
 # Figue
-figue = { version = "2.0.0" }
+figue = { version = "5.0.0-rc.0" }
 
 # Error handling
 eyre = "0.6"
@@ -173,15 +173,13 @@ url = { version = "2", features = ["serde"] }
 tower-lsp = "0.20"
 open = "5"
 dirs = "6.0.0"
-facet-typescript = { version = "0.44" }
+facet-typescript = { version = "0.50.0-rc.0" }
 time = { version = "0.3", features = ["formatting"] }
 tempfile = "3.24.0"
 
-# roam RPC framework
-roam = "7.0.0"
-roam-core = "7.0.0"
-roam-stream = "7.0.0"
-roam-local = "7.0.0"
+# vox RPC framework
+vox = "0.9.0-rc.0"
+vox-schema = "0.9.0-rc.0"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/crates/tracey-proto/Cargo.toml
+++ b/crates/tracey-proto/Cargo.toml
@@ -16,8 +16,9 @@ authors.workspace = true
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-# roam RPC framework
-roam = { workspace = true }
+# vox RPC framework
+vox = { workspace = true }
+vox-schema = { workspace = true }
 
 # API types (re-exported for convenience)
 tracey-api = { workspace = true }

--- a/crates/tracey-proto/src/lib.rs
+++ b/crates/tracey-proto/src/lib.rs
@@ -1,12 +1,12 @@
 //! Protocol definitions for the tracey daemon RPC service.
 //!
-//! This crate defines the `TraceyDaemon` service trait using roam's `#[service]`
+//! This crate defines the `TraceyDaemon` service trait using Vox's `#[service]`
 //! macro. The daemon exposes this service over a Unix socket, and bridges
 //! (HTTP, MCP, LSP) connect as clients.
 
 use facet::Facet;
-use roam::Tx;
 use tracey_core::RuleId;
+use vox::Tx;
 
 // Re-export API types for convenience
 pub use tracey_api::*;
@@ -302,6 +302,8 @@ pub struct DataUpdate {
     #[facet(default)]
     pub delta: Option<DeltaSummary>,
 }
+
+vox_schema::impl_reborrow_owned!(DataUpdate);
 
 /// Response for health check query.
 ///
@@ -640,7 +642,7 @@ pub struct LspDocumentRequest {
 ///
 /// This service is exposed by the daemon over a Unix socket. Bridges (HTTP, MCP, LSP)
 /// connect as clients and translate their protocols to/from these RPC calls.
-#[roam::service]
+#[vox::service]
 pub trait TraceyDaemon {
     // === Core Queries ===
 

--- a/crates/tracey/Cargo.toml
+++ b/crates/tracey/Cargo.toml
@@ -97,10 +97,8 @@ tower-lsp = { workspace = true }
 # Open URLs in browser
 open = { workspace = true }
 
-# roam RPC framework (for daemon architecture)
-roam = { workspace = true }
-roam-stream = { workspace = true }
-roam-local = { workspace = true }
+# vox RPC framework (for daemon architecture)
+vox = { workspace = true }
 dirs = { workspace = true }
 
 [features]
@@ -116,5 +114,5 @@ time = { workspace = true, features = ["formatting"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-roam-core = { workspace = true }
+vox = { workspace = true }
 walkdir = "2"

--- a/crates/tracey/build.rs
+++ b/crates/tracey/build.rs
@@ -196,6 +196,7 @@ fn build_dashboard() {
     println!("cargo:rerun-if-changed=src/bridge/http/dashboard/src");
     println!("cargo:rerun-if-changed=src/bridge/http/dashboard/index.html");
     println!("cargo:rerun-if-changed=src/bridge/http/dashboard/package.json");
+    println!("cargo:rerun-if-changed=src/bridge/http/dashboard/pnpm-workspace.yaml");
     println!("cargo:rerun-if-changed=src/bridge/http/dashboard/vite.config.ts");
 
     // Skip build if dist already exists in OUT_DIR (for faster incremental builds)
@@ -324,6 +325,7 @@ fn build_dashboard() {
     // Install dependencies if needed
     let status = shell_command("pnpm")
         .args(["install", "--frozen-lockfile"])
+        .env("CI", "true")
         .current_dir(dashboard_dir)
         .status()
         .expect("Failed to run pnpm install - is pnpm installed?");
@@ -335,6 +337,7 @@ fn build_dashboard() {
     // Build the dashboard (output goes to OUT_DIR/dashboard/dist)
     let status = shell_command("pnpm")
         .args(["run", "build"])
+        .env("CI", "true")
         .current_dir(dashboard_dir)
         .status()
         .expect("Failed to run pnpm build");

--- a/crates/tracey/skill/references/tracey-spec.md
+++ b/crates/tracey/skill/references/tracey-spec.md
@@ -825,7 +825,7 @@ The server MUST maintain a version identifier that changes when any source data 
 
 ## Daemon Architecture
 
-Tracey uses a daemon architecture where a single persistent daemon per workspace owns all state and computation. Protocol bridges (HTTP, LSP, MCP) connect as clients to the daemon via roam RPC over Unix sockets.
+Tracey uses a daemon architecture where a single persistent daemon per workspace owns all state and computation. Protocol bridges (HTTP, LSP, MCP) connect as clients to the daemon via Vox RPC over Unix sockets.
 
 ### Daemon Lifecycle
 
@@ -855,15 +855,15 @@ The daemon MUST maintain a virtual filesystem (VFS) overlay that stores in-memor
 r[daemon.state.blocking-rebuild]
 On file changes, the daemon MUST block all incoming requests until the rebuild completes. This ensures clients never see stale or inconsistent data.
 
-### roam Service
+### Vox Service
 
-r[daemon.roam.protocol]
-The daemon MUST expose a `TraceyDaemon` service via the roam RPC protocol.
+r[daemon.vox.protocol]
+The daemon MUST expose a `TraceyDaemon` service via the Vox RPC protocol.
 
-r[daemon.roam.unix-socket]
+r[daemon.vox.unix-socket]
 Communication between the daemon and bridges MUST occur over Unix domain sockets.
 
-r[daemon.roam.framing]
+r[daemon.vox.framing]
 Messages on the Unix socket MUST use COBS framing for reliable message boundary detection.
 
 ### VFS Overlay
@@ -883,13 +883,13 @@ When computing coverage, VFS overlay content MUST take precedence over disk cont
 ### Protocol Bridges
 
 r[daemon.bridge.http]
-The HTTP bridge MUST translate REST API requests to roam RPC calls and serve the dashboard frontend.
+The HTTP bridge MUST translate REST API requests to Vox RPC calls and serve the dashboard frontend.
 
 r[daemon.bridge.mcp]
-The MCP bridge MUST translate MCP tool calls to roam RPC calls, providing AI assistants access to coverage data.
+The MCP bridge MUST translate MCP tool calls to Vox RPC calls, providing AI assistants access to coverage data.
 
 r[daemon.bridge.lsp]
-The LSP bridge MUST translate LSP protocol messages to roam RPC calls and feed the VFS overlay with document open/change/close events.
+The LSP bridge MUST translate LSP protocol messages to Vox RPC calls and feed the VFS overlay with document open/change/close events.
 
 ### CLI Commands
 

--- a/crates/tracey/src/bridge/http/dashboard/package.json
+++ b/crates/tracey/src/bridge/http/dashboard/package.json
@@ -18,9 +18,6 @@
     "typescript": "^5.9.3",
     "vite": "^7.3.0"
   },
-  "pnpm": {
-    "allowBuild": ["@parcel/watcher", "esbuild"]
-  },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.0",
     "@codemirror/commands": "^6.10.1",

--- a/crates/tracey/src/bridge/http/dashboard/pnpm-workspace.yaml
+++ b/crates/tracey/src/bridge/http/dashboard/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true

--- a/crates/tracey/src/bridge/http/dashboard/src/api-types.ts
+++ b/crates/tracey/src/bridge/http/dashboard/src/api-types.ts
@@ -8,163 +8,91 @@
  * A validation error found in the spec or implementation.
  */
 export interface ValidationError {
-  /**
-   * Error code for programmatic handling
-   */
+  /** Error code for programmatic handling */
   code: ValidationErrorCode;
-  /**
-   * Human-readable error message
-   */
+  /** Human-readable error message */
   message: string;
-  /**
-   * File where the error was found (if applicable)
-   */
+  /** File where the error was found (if applicable) */
   file?: string;
-  /**
-   * Line number (if applicable)
-   */
+  /** Line number (if applicable) */
   line?: number;
-  /**
-   * Column number (if applicable)
-   */
+  /** Column number (if applicable) */
   column?: number;
-  /**
-   * Related rule IDs (for dependency errors)
-   */
+  /** Related rule IDs (for dependency errors) */
   relatedRules?: RuleId[];
-  /**
-   * The referenced rule ID (for StaleRequirement/UnknownRequirement errors)
-   */
+  /** The referenced rule ID (for StaleRequirement/UnknownRequirement errors) */
   referenceRuleId?: RuleId;
-  /**
-   * Original annotation text for unknown references (for example `r[impl auth.logn]`).
-   */
+  /** Original annotation text for unknown references (for example `r[impl auth.logn]`). */
   referenceText?: string;
 }
 
-/**
- * Structured rule ID representation.
- */
+/** Structured rule ID representation. */
 export interface RuleId {
-  /**
-   * Base rule ID without version suffix.
-   */
+  /** Base rule ID without version suffix. */
   base: string;
-  /**
-   * Normalized version number (unversioned IDs are version 1).
-   */
+  /** Normalized version number (unversioned IDs are version 1). */
   version: number;
 }
 
-/**
- * Error codes for validation errors
- */
+/** Error codes for validation errors */
 export type ValidationErrorCode = "circular_dependency" | "invalid_naming" | "unknown_requirement" | "stale_requirement" | "duplicate_requirement" | "unknown_prefix" | "impl_in_test_file" | "include_unparseable_file";
 
-/**
- * Validation results for a spec/implementation pair
- */
+/** Validation results for a spec/implementation pair */
 export interface ValidationResult {
-  /**
-   * Spec name
-   */
+  /** Spec name */
   spec: string;
-  /**
-   * Implementation name
-   */
+  /** Implementation name */
   implName: string;
-  /**
-   * List of validation errors found
-   */
+  /** List of validation errors found */
   errors: ValidationError[];
-  /**
-   * Number of warnings (non-fatal issues)
-   */
+  /** Number of warnings (non-fatal issues) */
   warningCount: number;
-  /**
-   * Number of errors (fatal issues)
-   */
+  /** Number of errors (fatal issues) */
   errorCount: number;
 }
 
-/**
- * Spec content (may span multiple files)
- */
+/** Spec content (may span multiple files) */
 export interface ApiSpecData {
   name: string;
-  /**
-   * Sections ordered by weight
-   */
+  /** Sections ordered by weight */
   sections: SpecSection[];
-  /**
-   * Outline with coverage info
-   */
+  /** Outline with coverage info */
   outline: OutlineEntry[];
-  /**
-   * HTML snippets to inject into the page head (e.g. mermaid.js loader)
-   */
+  /** HTML snippets to inject into the page head (e.g. mermaid.js loader) */
   head_injections?: string[];
 }
 
-/**
- * An entry in the spec outline (heading with coverage info)
- */
+/** An entry in the spec outline (heading with coverage info) */
 export interface OutlineEntry {
-  /**
-   * Heading text
-   */
+  /** Heading text */
   title: string;
-  /**
-   * Slug for linking
-   */
+  /** Slug for linking */
   slug: string;
-  /**
-   * Heading level (1-6)
-   */
+  /** Heading level (1-6) */
   level: number;
-  /**
-   * Direct coverage (rules directly under this heading)
-   */
+  /** Direct coverage (rules directly under this heading) */
   coverage: OutlineCoverage;
-  /**
-   * Aggregated coverage (includes all nested rules)
-   */
+  /** Aggregated coverage (includes all nested rules) */
   aggregated: OutlineCoverage;
 }
 
-/**
- * Coverage counts for an outline entry
- */
+/** Coverage counts for an outline entry */
 export interface OutlineCoverage {
-  /**
-   * Number of rules with implementation refs
-   */
+  /** Number of rules with implementation refs */
   implCount: number;
-  /**
-   * Number of rules with verification refs
-   */
+  /** Number of rules with verification refs */
   verifyCount: number;
-  /**
-   * Total number of rules
-   */
+  /** Total number of rules */
   total: number;
 }
 
-/**
- * A section of a spec (one source file)
- */
+/** A section of a spec (one source file) */
 export interface SpecSection {
-  /**
-   * Source file path
-   */
+  /** Source file path */
   sourceFile: string;
-  /**
-   * Rendered HTML content
-   */
+  /** Rendered HTML content */
   html: string;
-  /**
-   * Weight for ordering (from frontmatter)
-   */
+  /** Weight for ordering (from frontmatter) */
   weight: number;
 }
 
@@ -173,55 +101,35 @@ export interface ApiCodeUnit {
   name?: string;
   startLine: number;
   endLine: number;
-  /**
-   * Rule references found in this code unit's comments
-   */
+  /** Rule references found in this code unit's comments */
   ruleRefs: string[];
 }
 
-/**
- * Single file with full coverage details
- */
+/** Single file with full coverage details */
 export interface ApiFileData {
   path: string;
   content: string;
-  /**
-   * Syntax-highlighted HTML content
-   */
+  /** Syntax-highlighted HTML content */
   html: string;
-  /**
-   * Code units in this file with their coverage
-   */
+  /** Code units in this file with their coverage */
   units: ApiCodeUnit[];
 }
 
 export interface ApiFileEntry {
   path: string;
-  /**
-   * Number of code units in this file
-   */
+  /** Number of code units in this file */
   totalUnits: number;
-  /**
-   * Number of covered code units
-   */
+  /** Number of covered code units */
   coveredUnits: number;
 }
 
-/**
- * Reverse traceability: file tree with coverage info
- */
+/** Reverse traceability: file tree with coverage info */
 export interface ApiReverseData {
-  /**
-   * Total code units across all files
-   */
+  /** Total code units across all files */
   totalUnits: number;
-  /**
-   * Code units with at least one rule reference
-   */
+  /** Code units with at least one rule reference */
   coveredUnits: number;
-  /**
-   * File tree with coverage info
-   */
+  /** File tree with coverage info */
   files: ApiFileEntry[];
 }
 
@@ -232,26 +140,18 @@ export interface ApiCodeRef {
 
 export interface ApiRule {
   id: RuleId;
-  /**
-   * Raw markdown source (without r[...] marker, but with `>` prefixes for blockquote rules)
-   */
+  /** Raw markdown source (without r[...] marker, but with `>` prefixes for blockquote rules) */
   raw: string;
-  /**
-   * Rendered HTML (for dashboard display)
-   */
+  /** Rendered HTML (for dashboard display) */
   html: string;
   status?: string;
   level?: string;
   sourceFile?: string;
   sourceLine?: number;
   sourceColumn?: number;
-  /**
-   * Section slug (heading ID) that this rule belongs to
-   */
+  /** Section slug (heading ID) that this rule belongs to */
   section?: string;
-  /**
-   * Section title (heading text) that this rule belongs to
-   */
+  /** Section title (heading text) that this rule belongs to */
   sectionTitle?: string;
   implRefs: ApiCodeRef[];
   verifyRefs: ApiCodeRef[];
@@ -261,21 +161,15 @@ export interface ApiRule {
    * A stale rule is not counted as covered.
    */
   isStale?: boolean;
-  /**
-   * Stale references pointing to older versions of this rule.
-   */
+  /** Stale references pointing to older versions of this rule. */
   staleRefs?: ApiStaleRef[];
 }
 
-/**
- * A stale reference: code points to an older version of a rule.
- */
+/** A stale reference: code points to an older version of a rule. */
 export interface ApiStaleRef {
   file: string;
   line: number;
-  /**
-   * The rule ID referenced in code (older version)
-   */
+  /** The rule ID referenced in code (older version) */
   reference_id: RuleId;
 }
 
@@ -284,9 +178,7 @@ export interface ApiSpecForward {
   rules: ApiRule[];
 }
 
-/**
- * Forward traceability: rules with their code references
- */
+/** Forward traceability: rules with their code references */
 export interface ApiForwardData {
   specs: ApiSpecForward[];
 }
@@ -298,31 +190,21 @@ export interface ApiSpecInfo {
    * Prefix used in annotations (e.g., "r" for r[req.id])
    */
   prefix: string;
-  /**
-   * Path to spec file(s) if local
-   */
+  /** Path to spec file(s) if local */
   source?: string;
-  /**
-   * Canonical URL for the specification (e.g., a GitHub repository)
-   */
+  /** Canonical URL for the specification (e.g., a GitHub repository) */
   sourceUrl?: string;
-  /**
-   * Available implementations for this spec
-   */
+  /** Available implementations for this spec */
   implementations: string[];
 }
 
-/**
- * Project configuration info
- */
+/** Project configuration info */
 export interface ApiConfig {
   projectRoot: string;
   specs: ApiSpecInfo[];
 }
 
-/**
- * Git status for a file
- */
+/** Git status for a file */
 export type GitStatus = "dirty" | "staged" | "clean" | "unknown";
 
 

--- a/crates/tracey/src/bridge/http/mod.rs
+++ b/crates/tracey/src/bridge/http/mod.rs
@@ -354,9 +354,9 @@ impl ApiError {
     }
 }
 
-/// Convert roam RPC result to Result<T, Response>
+/// Convert Vox RPC result to Result<T, Response>
 #[allow(clippy::result_large_err)]
-fn rpc<T, E: std::fmt::Debug>(res: Result<T, roam::RoamError<E>>) -> Result<T, Response> {
+fn rpc<T, E: std::fmt::Debug>(res: Result<T, vox::VoxError<E>>) -> Result<T, Response> {
     res.map_err(|e| ApiError::rpc_error(format!("{:?}", e)))
 }
 

--- a/crates/tracey/src/bridge/lsp.rs
+++ b/crates/tracey/src/bridge/lsp.rs
@@ -22,8 +22,8 @@ use crate::daemon::{DaemonClient, new_client};
 use tracey_core::{RefVerb, parse_rule_id};
 use tracey_proto::*;
 
-/// Convert roam RPC result to a simple Result
-fn rpc<T, E: std::fmt::Debug>(res: Result<T, roam::RoamError<E>>) -> Result<T, String> {
+/// Convert Vox RPC result to a simple Result
+fn rpc<T, E: std::fmt::Debug>(res: Result<T, vox::VoxError<E>>) -> Result<T, String> {
     res.map_err(|e| format!("RPC error: {:?}", e))
 }
 
@@ -664,7 +664,7 @@ impl Backend {
         project_state: Arc<Mutex<LspProjectState>>,
     ) {
         let mut last_version: Option<u64> = None;
-        let (tx, mut rx) = roam::channel::<DataUpdate>();
+        let (tx, mut rx) = vox::channel::<DataUpdate>();
         let subscribe_client = daemon_client.clone();
         let subscribe_task = tokio::spawn(async move { subscribe_client.subscribe(tx).await });
 
@@ -677,7 +677,7 @@ impl Backend {
             }
             let next_version =
                 match tokio::time::timeout(Duration::from_millis(500), rx.recv()).await {
-                    Ok(Ok(Some(update))) => Some(update.version),
+                    Ok(Ok(Some(update))) => Some(update.get().version),
                     Ok(Ok(None)) => daemon_client.version().await.ok(),
                     Ok(Err(_)) => daemon_client.version().await.ok(),
                     Err(_) => daemon_client.version().await.ok(),

--- a/crates/tracey/src/bridge/mod.rs
+++ b/crates/tracey/src/bridge/mod.rs
@@ -1,7 +1,7 @@
 //! Protocol bridges to the tracey daemon.
 //!
 //! Each bridge translates a specific protocol (HTTP, LSP, MCP) to the
-//! daemon's roam RPC interface. Bridges are thin protocol adapters that
+//! daemon's Vox RPC interface. Bridges are thin protocol adapters that
 //! connect as clients to the daemon.
 
 pub mod export;

--- a/crates/tracey/src/daemon/client.rs
+++ b/crates/tracey/src/daemon/client.rs
@@ -1,6 +1,6 @@
 //! Client for connecting to the tracey daemon.
 //!
-//! Uses roam v7 session builders.
+//! Uses Vox session builders.
 
 use std::fs::OpenOptions;
 use std::future::Future;
@@ -26,7 +26,7 @@ pub fn new_client(project_root: PathBuf) -> DaemonClient {
 }
 
 impl DaemonClient {
-    async fn connect_inner(&self) -> io::Result<roam_stream::LocalLink> {
+    async fn connect_inner(&self) -> io::Result<vox::transport::local::LocalLink> {
         let start = Instant::now();
         debug!(
             project_root = %self.project_root.display(),
@@ -41,10 +41,10 @@ impl DaemonClient {
         Ok(stream)
     }
 
-    async fn with_client<T, E, F, Fut>(&self, f: F) -> Result<T, roam::RoamError<E>>
+    async fn with_client<T, E, F, Fut>(&self, f: F) -> Result<T, vox::VoxError<E>>
     where
         F: FnOnce(TraceyDaemonClient) -> Fut,
-        Fut: Future<Output = Result<T, roam::RoamError<E>>>,
+        Fut: Future<Output = Result<T, vox::VoxError<E>>>,
     {
         let start = Instant::now();
         let callsite = std::panic::Location::caller();
@@ -61,18 +61,18 @@ impl DaemonClient {
                     callsite = format_args!("{}:{}", callsite.file(), callsite.line()),
                     "daemon client: connect_inner failed"
                 );
-                return Err(roam::RoamError::Cancelled);
+                return Err(vox::VoxError::Cancelled);
             }
         };
-        let (client, _session_handle) = match roam::initiator(stream)
-            .establish::<TraceyDaemonClient>(())
+        let client = match vox::initiator_on(stream)
+            .establish::<TraceyDaemonClient>()
             .await
         {
             Ok(parts) => {
                 debug!(
                     elapsed_ms = start.elapsed().as_millis(),
                     callsite = format_args!("{}:{}", callsite.file(), callsite.line()),
-                    "daemon client: roam session established"
+                    "daemon client: vox session established"
                 );
                 parts
             }
@@ -81,9 +81,9 @@ impl DaemonClient {
                     elapsed_ms = start.elapsed().as_millis(),
                     error = %e,
                     callsite = format_args!("{}:{}", callsite.file(), callsite.line()),
-                    "daemon client: roam session establish failed"
+                    "daemon client: vox session establish failed"
                 );
-                return Err(roam::RoamError::Cancelled);
+                return Err(vox::VoxError::Cancelled);
             }
         };
         let result = f(client).await;
@@ -99,83 +99,83 @@ impl DaemonClient {
                 warn!(
                     elapsed_ms = start.elapsed().as_millis(),
                     callsite = format_args!("{}:{}", callsite.file(), callsite.line()),
-                    "daemon client: with_client returned roam error"
+                    "daemon client: with_client returned vox error"
                 );
             }
         }
         result
     }
 
-    pub async fn status(&self) -> Result<tracey_proto::StatusResponse, roam::RoamError> {
+    pub async fn status(&self) -> Result<tracey_proto::StatusResponse, vox::VoxError> {
         self.with_client(|c| async move { c.status().await }).await
     }
     pub async fn uncovered(
         &self,
         req: tracey_proto::UncoveredRequest,
-    ) -> Result<tracey_proto::UncoveredResponse, roam::RoamError> {
+    ) -> Result<tracey_proto::UncoveredResponse, vox::VoxError> {
         self.with_client(|c| async move { c.uncovered(req).await })
             .await
     }
     pub async fn untested(
         &self,
         req: tracey_proto::UntestedRequest,
-    ) -> Result<tracey_proto::UntestedResponse, roam::RoamError> {
+    ) -> Result<tracey_proto::UntestedResponse, vox::VoxError> {
         self.with_client(|c| async move { c.untested(req).await })
             .await
     }
     pub async fn stale(
         &self,
         req: tracey_proto::StaleRequest,
-    ) -> Result<tracey_proto::StaleResponse, roam::RoamError> {
+    ) -> Result<tracey_proto::StaleResponse, vox::VoxError> {
         self.with_client(|c| async move { c.stale(req).await })
             .await
     }
     pub async fn unmapped(
         &self,
         req: tracey_proto::UnmappedRequest,
-    ) -> Result<tracey_proto::UnmappedResponse, roam::RoamError> {
+    ) -> Result<tracey_proto::UnmappedResponse, vox::VoxError> {
         self.with_client(|c| async move { c.unmapped(req).await })
             .await
     }
     pub async fn rule(
         &self,
         rule_id: tracey_core::RuleId,
-    ) -> Result<Option<tracey_proto::RuleInfo>, roam::RoamError> {
+    ) -> Result<Option<tracey_proto::RuleInfo>, vox::VoxError> {
         self.with_client(|c| async move { c.rule(rule_id).await })
             .await
     }
-    pub async fn config(&self) -> Result<tracey_api::ApiConfig, roam::RoamError> {
+    pub async fn config(&self) -> Result<tracey_api::ApiConfig, vox::VoxError> {
         self.with_client(|c| async move { c.config().await }).await
     }
-    pub async fn vfs_open(&self, path: String, content: String) -> Result<(), roam::RoamError> {
+    pub async fn vfs_open(&self, path: String, content: String) -> Result<(), vox::VoxError> {
         self.with_client(|c| async move { c.vfs_open(path, content).await })
             .await
     }
-    pub async fn vfs_change(&self, path: String, content: String) -> Result<(), roam::RoamError> {
+    pub async fn vfs_change(&self, path: String, content: String) -> Result<(), vox::VoxError> {
         self.with_client(|c| async move { c.vfs_change(path, content).await })
             .await
     }
-    pub async fn vfs_close(&self, path: String) -> Result<(), roam::RoamError> {
+    pub async fn vfs_close(&self, path: String) -> Result<(), vox::VoxError> {
         self.with_client(|c| async move { c.vfs_close(path).await })
             .await
     }
-    pub async fn reload(&self) -> Result<tracey_proto::ReloadResponse, roam::RoamError> {
+    pub async fn reload(&self) -> Result<tracey_proto::ReloadResponse, vox::VoxError> {
         self.with_client(|c| async move { c.reload().await }).await
     }
-    pub async fn version(&self) -> Result<u64, roam::RoamError> {
+    pub async fn version(&self) -> Result<u64, vox::VoxError> {
         self.with_client(|c| async move { c.version().await }).await
     }
-    pub async fn health(&self) -> Result<tracey_proto::HealthResponse, roam::RoamError> {
+    pub async fn health(&self) -> Result<tracey_proto::HealthResponse, vox::VoxError> {
         self.with_client(|c| async move { c.health().await }).await
     }
-    pub async fn shutdown(&self) -> Result<(), roam::RoamError> {
+    pub async fn shutdown(&self) -> Result<(), vox::VoxError> {
         self.with_client(|c| async move { c.shutdown().await })
             .await
     }
     pub async fn subscribe(
         &self,
-        updates: roam::Tx<tracey_proto::DataUpdate>,
-    ) -> Result<(), roam::RoamError> {
+        updates: vox::Tx<tracey_proto::DataUpdate>,
+    ) -> Result<(), vox::VoxError> {
         self.with_client(|c| async move { c.subscribe(updates).await })
             .await
     }
@@ -183,7 +183,7 @@ impl DaemonClient {
         &self,
         spec: String,
         impl_name: String,
-    ) -> Result<Option<tracey_api::ApiSpecForward>, roam::RoamError> {
+    ) -> Result<Option<tracey_api::ApiSpecForward>, vox::VoxError> {
         self.with_client(|c| async move { c.forward(spec, impl_name).await })
             .await
     }
@@ -191,21 +191,21 @@ impl DaemonClient {
         &self,
         spec: String,
         impl_name: String,
-    ) -> Result<Option<tracey_api::ApiReverseData>, roam::RoamError> {
+    ) -> Result<Option<tracey_api::ApiReverseData>, vox::VoxError> {
         self.with_client(|c| async move { c.reverse(spec, impl_name).await })
             .await
     }
     pub async fn file(
         &self,
         req: tracey_proto::FileRequest,
-    ) -> Result<Option<tracey_api::ApiFileData>, roam::RoamError> {
+    ) -> Result<Option<tracey_api::ApiFileData>, vox::VoxError> {
         self.with_client(|c| async move { c.file(req).await }).await
     }
     pub async fn spec_content(
         &self,
         spec: String,
         impl_name: String,
-    ) -> Result<Option<tracey_api::ApiSpecData>, roam::RoamError> {
+    ) -> Result<Option<tracey_api::ApiSpecData>, vox::VoxError> {
         self.with_client(|c| async move { c.spec_content(spec, impl_name).await })
             .await
     }
@@ -213,143 +213,143 @@ impl DaemonClient {
         &self,
         query: String,
         limit: u32,
-    ) -> Result<Vec<tracey_proto::SearchResult>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::SearchResult>, vox::VoxError> {
         self.with_client(|c| async move { c.search(query, limit).await })
             .await
     }
     pub async fn update_file_range(
         &self,
         req: tracey_proto::UpdateFileRangeRequest,
-    ) -> Result<(), roam::RoamError<tracey_proto::UpdateError>> {
+    ) -> Result<(), vox::VoxError<tracey_proto::UpdateError>> {
         self.with_client(|c| async move { c.update_file_range(req).await })
             .await
     }
-    pub async fn is_test_file(&self, path: String) -> Result<bool, roam::RoamError> {
+    pub async fn is_test_file(&self, path: String) -> Result<bool, vox::VoxError> {
         self.with_client(|c| async move { c.is_test_file(path).await })
             .await
     }
     pub async fn lsp_hover(
         &self,
         req: tracey_proto::LspPositionRequest,
-    ) -> Result<Option<tracey_proto::HoverInfo>, roam::RoamError> {
+    ) -> Result<Option<tracey_proto::HoverInfo>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_hover(req).await })
             .await
     }
     pub async fn lsp_definition(
         &self,
         req: tracey_proto::LspPositionRequest,
-    ) -> Result<Vec<tracey_proto::LspLocation>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspLocation>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_definition(req).await })
             .await
     }
     pub async fn lsp_implementation(
         &self,
         req: tracey_proto::LspPositionRequest,
-    ) -> Result<Vec<tracey_proto::LspLocation>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspLocation>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_implementation(req).await })
             .await
     }
     pub async fn lsp_references(
         &self,
         req: tracey_proto::LspReferencesRequest,
-    ) -> Result<Vec<tracey_proto::LspLocation>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspLocation>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_references(req).await })
             .await
     }
     pub async fn lsp_completions(
         &self,
         req: tracey_proto::LspPositionRequest,
-    ) -> Result<Vec<tracey_proto::LspCompletionItem>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspCompletionItem>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_completions(req).await })
             .await
     }
     pub async fn lsp_workspace_diagnostics(
         &self,
-    ) -> Result<Vec<tracey_proto::LspFileDiagnostics>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspFileDiagnostics>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_workspace_diagnostics().await })
             .await
     }
     pub async fn lsp_document_symbols(
         &self,
         req: tracey_proto::LspDocumentRequest,
-    ) -> Result<Vec<tracey_proto::LspSymbol>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspSymbol>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_document_symbols(req).await })
             .await
     }
     pub async fn lsp_workspace_symbols(
         &self,
         query: String,
-    ) -> Result<Vec<tracey_proto::LspSymbol>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspSymbol>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_workspace_symbols(query).await })
             .await
     }
     pub async fn lsp_semantic_tokens(
         &self,
         req: tracey_proto::LspDocumentRequest,
-    ) -> Result<Vec<tracey_proto::LspSemanticToken>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspSemanticToken>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_semantic_tokens(req).await })
             .await
     }
     pub async fn lsp_code_lens(
         &self,
         req: tracey_proto::LspDocumentRequest,
-    ) -> Result<Vec<tracey_proto::LspCodeLens>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspCodeLens>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_code_lens(req).await })
             .await
     }
     pub async fn lsp_inlay_hints(
         &self,
         req: tracey_proto::InlayHintsRequest,
-    ) -> Result<Vec<tracey_proto::LspInlayHint>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspInlayHint>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_inlay_hints(req).await })
             .await
     }
     pub async fn lsp_prepare_rename(
         &self,
         req: tracey_proto::LspPositionRequest,
-    ) -> Result<Option<tracey_proto::PrepareRenameResult>, roam::RoamError> {
+    ) -> Result<Option<tracey_proto::PrepareRenameResult>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_prepare_rename(req).await })
             .await
     }
     pub async fn lsp_rename(
         &self,
         req: tracey_proto::LspRenameRequest,
-    ) -> Result<Vec<tracey_proto::LspTextEdit>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspTextEdit>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_rename(req).await })
             .await
     }
     pub async fn lsp_code_actions(
         &self,
         req: tracey_proto::LspPositionRequest,
-    ) -> Result<Vec<tracey_proto::LspCodeAction>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspCodeAction>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_code_actions(req).await })
             .await
     }
     pub async fn lsp_document_highlight(
         &self,
         req: tracey_proto::LspPositionRequest,
-    ) -> Result<Vec<tracey_proto::LspLocation>, roam::RoamError> {
+    ) -> Result<Vec<tracey_proto::LspLocation>, vox::VoxError> {
         self.with_client(|c| async move { c.lsp_document_highlight(req).await })
             .await
     }
     pub async fn validate(
         &self,
         req: tracey_proto::ValidateRequest,
-    ) -> Result<tracey_api::ValidationResult, roam::RoamError> {
+    ) -> Result<tracey_api::ValidationResult, vox::VoxError> {
         self.with_client(|c| async move { c.validate(req).await })
             .await
     }
     pub async fn config_add_exclude(
         &self,
         req: tracey_proto::ConfigPatternRequest,
-    ) -> Result<(), roam::RoamError<String>> {
+    ) -> Result<(), vox::VoxError<String>> {
         self.with_client(|c| async move { c.config_add_exclude(req).await })
             .await
     }
     pub async fn config_add_include(
         &self,
         req: tracey_proto::ConfigPatternRequest,
-    ) -> Result<(), roam::RoamError<String>> {
+    ) -> Result<(), vox::VoxError<String>> {
         self.with_client(|c| async move { c.config_add_include(req).await })
             .await
     }
@@ -383,7 +383,7 @@ impl DaemonConnector {
         pid: u32,
         endpoint: &str,
         timeout: Duration,
-    ) -> io::Result<Option<roam_stream::LocalLink>> {
+    ) -> io::Result<Option<vox::transport::local::LocalLink>> {
         let start = Instant::now();
         let mut last_error: Option<String> = None;
 
@@ -396,7 +396,7 @@ impl DaemonConnector {
                 return Ok(None);
             }
 
-            match roam_stream::LocalLink::connect(&endpoint).await {
+            match vox::transport::local::LocalLink::connect(&endpoint).await {
                 Ok(stream) => return Ok(Some(stream)),
                 Err(e) => {
                     last_error = Some(e.to_string());
@@ -511,7 +511,7 @@ impl DaemonConnector {
     }
 
     /// Wait for the daemon endpoint to appear and connect.
-    async fn wait_and_connect(&self) -> io::Result<roam_stream::LocalLink> {
+    async fn wait_and_connect(&self) -> io::Result<vox::transport::local::LocalLink> {
         let endpoint = local_endpoint(&self.project_root);
         let start = Instant::now();
         let timeout = Duration::from_secs(5);
@@ -534,7 +534,7 @@ impl DaemonConnector {
                 ));
             }
 
-            match roam_stream::LocalLink::connect(&endpoint).await {
+            match vox::transport::local::LocalLink::connect(&endpoint).await {
                 Ok(stream) => return Ok(stream),
                 Err(e) => {
                     last_connect_error = Some(e.to_string());
@@ -580,7 +580,7 @@ fn kill_pid(pid: u32) {
 fn kill_pid(_pid: u32) {}
 
 impl DaemonConnector {
-    pub async fn connect(&self) -> io::Result<roam_stream::LocalLink> {
+    pub async fn connect(&self) -> io::Result<vox::transport::local::LocalLink> {
         let endpoint = local_endpoint(&self.project_root);
         debug!(
             "DaemonConnector::connect project_root={} endpoint={:?}",
@@ -599,7 +599,7 @@ impl DaemonConnector {
 
                 if alive && version_ok {
                     // Happy path: daemon should be running.
-                    match roam_stream::LocalLink::connect(&endpoint).await {
+                    match vox::transport::local::LocalLink::connect(&endpoint).await {
                         Ok(stream) => return Ok(stream),
                         Err(e) => {
                             let age = pid_file_age(&self.project_root);
@@ -627,7 +627,7 @@ impl DaemonConnector {
                         }
                     }
                     // Socket connect failed despite live PID — stale socket.
-                    let _ = roam_local::remove_endpoint(&endpoint);
+                    let _ = vox::transport::local::remove_endpoint(&endpoint);
                     let _ = std::fs::remove_file(pid_file_path(&self.project_root));
                 } else {
                     // Kill if alive but wrong version, then clean up.
@@ -639,7 +639,7 @@ impl DaemonConnector {
                         );
                         kill_pid(pid);
                     }
-                    let _ = roam_local::remove_endpoint(&endpoint);
+                    let _ = vox::transport::local::remove_endpoint(&endpoint);
                     let _ = std::fs::remove_file(pid_file_path(&self.project_root));
                 }
             }
@@ -647,12 +647,12 @@ impl DaemonConnector {
                 debug!("No PID file found for {}", self.project_root.display());
                 // No PID file — remove stale socket if present.
                 // r[impl daemon.lifecycle.stale-socket]
-                if roam_local::endpoint_exists(&endpoint) {
+                if vox::transport::local::endpoint_exists(&endpoint) {
                     warn!(
                         "No PID file but endpoint exists at {:?}; removing stale endpoint",
                         endpoint
                     );
-                    let _ = roam_local::remove_endpoint(&endpoint);
+                    let _ = vox::transport::local::remove_endpoint(&endpoint);
                 }
             }
         }
@@ -665,7 +665,7 @@ impl DaemonConnector {
         if let Some((pid, version)) = read_pid_file(&self.project_root)
             && is_pid_alive(pid)
             && version == tracey_proto::PROTOCOL_VERSION
-            && let Ok(stream) = roam_stream::LocalLink::connect(&endpoint).await
+            && let Ok(stream) = vox::transport::local::LocalLink::connect(&endpoint).await
         {
             debug!(
                 "Daemon became available while waiting for startup lock (pid={})",

--- a/crates/tracey/src/daemon/mod.rs
+++ b/crates/tracey/src/daemon/mod.rs
@@ -32,12 +32,12 @@ pub mod service;
 pub mod watcher;
 
 use eyre::{Result, WrapErr};
-use roam_stream::LocalLinkAcceptor;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tracing::{debug, error, info, warn};
+use vox::transport::local::LocalLinkAcceptor;
 
 use service::TraceyDaemonDispatcher;
 use watcher::{WatcherEvent, WatcherManager, WatcherState};
@@ -105,7 +105,7 @@ pub fn ensure_state_dir(project_root: &Path) -> Result<PathBuf> {
 /// On Unix, this returns a string representing a path to `<state_dir>/daemon.sock`.
 /// On Windows, this returns a string representing a named pipe path like `\\.\pipe\tracey-{hash}`.
 ///
-/// r[impl daemon.roam.unix-socket]
+/// r[impl daemon.vox.unix-socket]
 #[cfg(unix)]
 pub fn local_endpoint(project_root: &Path) -> String {
     state_dir(project_root)
@@ -209,7 +209,7 @@ impl Drop for PidFile {
 
 /// Run the daemon for the given workspace.
 ///
-/// r[impl daemon.roam.protocol]
+/// r[impl daemon.vox.protocol]
 ///
 /// This function blocks until the daemon exits (idle timeout or signal).
 pub async fn run(project_root: PathBuf, config_path: PathBuf) -> Result<()> {
@@ -227,12 +227,12 @@ pub async fn run(project_root: PathBuf, config_path: PathBuf) -> Result<()> {
 
     // r[impl daemon.lifecycle.stale-socket]
     // Remove stale endpoint if it exists; if it's alive, fail fast instead.
-    if roam_local::endpoint_exists(&endpoint) {
-        if roam_local::connect(&endpoint).await.is_ok() {
+    if vox::transport::local::endpoint_exists(&endpoint) {
+        if vox::transport::local::connect(&endpoint).await.is_ok() {
             eyre::bail!("Daemon already running at {}", endpoint);
         } else {
             info!("Removing stale socket at {}", endpoint);
-            let _ = roam_local::remove_endpoint(&endpoint);
+            let _ = vox::transport::local::remove_endpoint(&endpoint);
         }
     }
 
@@ -468,14 +468,14 @@ pub async fn run(project_root: PathBuf, config_path: PathBuf) -> Result<()> {
     ));
     let start_time = Instant::now();
 
-    // Accept connections and handle roam RPC
+    // Accept connections and handle Vox RPC
     loop {
         // Check for shutdown signal or accept with timeout
         let accept_result = tokio::select! {
             _ = shutdown_rx.changed() => {
                 if *shutdown_rx.borrow() {
                     info!("Shutdown signal received");
-                    let _ = roam_local::remove_endpoint(&endpoint);
+                    let _ = vox::transport::local::remove_endpoint(&endpoint);
                     return Ok(());
                 }
                 continue;
@@ -498,18 +498,18 @@ pub async fn run(project_root: PathBuf, config_path: PathBuf) -> Result<()> {
                     let (session_task_tx, session_task_rx) =
                         tokio::sync::oneshot::channel::<tokio::task::JoinHandle<()>>();
 
-                    match roam::acceptor(stream)
+                    match vox::acceptor_on(stream)
                         .spawn_fn(move |fut| {
                             let handle = tokio::spawn(fut);
                             let _ = session_task_tx.send(handle);
                         })
-                        .establish::<tracey_proto::TraceyDaemonClient>(dispatcher)
+                        .on_connection(dispatcher)
+                        .establish::<tracey_proto::TraceyDaemonClient>()
                         .await
                     {
-                        Ok((client_guard, session_handle)) => {
+                        Ok(client_guard) => {
                             info!("Connection established");
                             let _client_guard = client_guard;
-                            let _session_handle = session_handle;
                             if let Ok(session_task) = session_task_rx.await {
                                 let _ = session_task.await;
                             }
@@ -535,7 +535,7 @@ pub async fn run(project_root: PathBuf, config_path: PathBuf) -> Result<()> {
                 if idle_secs >= DEFAULT_IDLE_TIMEOUT_SECS {
                     info!("No connections for {} seconds, shutting down", idle_secs);
                     // Clean up endpoint
-                    let _ = roam_local::remove_endpoint(&endpoint);
+                    let _ = vox::transport::local::remove_endpoint(&endpoint);
                     return Ok(());
                 }
             }
@@ -714,12 +714,12 @@ async fn run_smart_watcher(
 #[allow(dead_code)]
 pub async fn is_running(project_root: &Path) -> bool {
     let endpoint = local_endpoint(project_root);
-    if !roam_local::endpoint_exists(&endpoint) {
+    if !vox::transport::local::endpoint_exists(&endpoint) {
         return false;
     }
 
     // Try to connect
-    match roam_local::connect(&endpoint).await {
+    match vox::transport::local::connect(&endpoint).await {
         Ok(_) => true,
         Err(_) => {
             // Endpoint exists but can't connect - stale
@@ -731,9 +731,9 @@ pub async fn is_running(project_root: &Path) -> bool {
 /// Connect to a running daemon, or return an error.
 #[allow(dead_code)]
 #[cfg(unix)]
-pub async fn connect(project_root: &Path) -> Result<roam_local::LocalStream> {
+pub async fn connect(project_root: &Path) -> Result<vox::transport::local::LocalStream> {
     let endpoint = local_endpoint(project_root);
-    roam_local::connect(&endpoint)
+    vox::transport::local::connect(&endpoint)
         .await
         .wrap_err_with(|| format!("Failed to connect to daemon at {}", endpoint))
 }
@@ -741,9 +741,9 @@ pub async fn connect(project_root: &Path) -> Result<roam_local::LocalStream> {
 /// Connect to a running daemon, or return an error.
 #[allow(dead_code)]
 #[cfg(windows)]
-pub async fn connect(project_root: &Path) -> Result<roam_local::LocalStream> {
+pub async fn connect(project_root: &Path) -> Result<vox::transport::local::LocalStream> {
     let endpoint = local_endpoint(project_root);
-    roam_local::connect(&endpoint)
+    vox::transport::local::connect(&endpoint)
         .await
         .wrap_err_with(|| format!("Failed to connect to daemon at {}", endpoint))
 }

--- a/crates/tracey/src/daemon/service.rs
+++ b/crates/tracey/src/daemon/service.rs
@@ -1,6 +1,6 @@
 //! TraceyDaemon service implementation.
 //!
-//! Implements the roam RPC service by delegating to the Engine.
+//! Implements the Vox RPC service by delegating to the Engine.
 
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -12,7 +12,7 @@ use super::engine::Engine;
 use super::watcher::WatcherState;
 use crate::rule_suggestions::suggest_similar_rule_ids;
 use crate::server::QueryEngine;
-use roam::Tx;
+use vox::Tx;
 
 // Re-export the generated dispatcher from tracey-proto
 pub use tracey_proto::TraceyDaemonDispatcher;

--- a/crates/tracey/src/main.rs
+++ b/crates/tracey/src/main.rs
@@ -1023,7 +1023,7 @@ async fn show_status(root: Option<PathBuf>, json: bool) -> Result<()> {
     let endpoint = daemon::local_endpoint(&project_root);
 
     // Try to connect without auto-starting
-    let stream = match roam_stream::LocalLink::connect(&endpoint).await {
+    let stream = match vox::transport::local::LocalLink::connect(&endpoint).await {
         Ok(s) => s,
         Err(_) => {
             if json {
@@ -1035,8 +1035,8 @@ async fn show_status(root: Option<PathBuf>, json: bool) -> Result<()> {
         }
     };
 
-    let (client, _session_handle) = roam::initiator(stream)
-        .establish::<tracey_proto::TraceyDaemonClient>(())
+    let client = vox::initiator_on(stream)
+        .establish::<tracey_proto::TraceyDaemonClient>()
         .await
         .map_err(|e| eyre::eyre!("failed to connect to daemon: {e:?}"))?;
 
@@ -1410,16 +1410,16 @@ async fn kill_daemon(root: Option<PathBuf>) -> Result<()> {
     let endpoint = daemon::local_endpoint(&project_root);
 
     // Check if endpoint exists
-    if !roam_local::endpoint_exists(&endpoint) {
+    if !vox::transport::local::endpoint_exists(&endpoint) {
         println!("{}: No daemon running", "Info".cyan());
         return Ok(());
     }
 
     // Try to connect and send shutdown
-    match roam_stream::LocalLink::connect(&endpoint).await {
+    match vox::transport::local::LocalLink::connect(&endpoint).await {
         Ok(stream) => {
-            let (client, _session_handle) = roam::initiator(stream)
-                .establish::<tracey_proto::TraceyDaemonClient>(())
+            let client = vox::initiator_on(stream)
+                .establish::<tracey_proto::TraceyDaemonClient>()
                 .await
                 .map_err(|e| eyre::eyre!("failed to connect to daemon: {e:?}"))?;
 
@@ -1448,7 +1448,7 @@ async fn kill_daemon(root: Option<PathBuf>) -> Result<()> {
                 "{}: Daemon not responding, cleaning up stale socket",
                 "Info".cyan()
             );
-            let _ = roam_local::remove_endpoint(&endpoint);
+            let _ = vox::transport::local::remove_endpoint(&endpoint);
             println!("{}: Cleaned up", "Success".green());
         }
     }

--- a/crates/tracey/tests/common/mod.rs
+++ b/crates/tracey/tests/common/mod.rs
@@ -5,10 +5,10 @@
 use std::path::PathBuf;
 use std::sync::Once;
 
-use roam_core::memory_link_pair as memory_transport_pair;
 use tracey_proto::{TraceyDaemonClient, TraceyDaemonDispatcher};
 use tracing::debug;
 use tracing_subscriber::EnvFilter;
+use vox::memory_link_pair as memory_transport_pair;
 
 static TEST_TRACING: Once = Once::new();
 
@@ -41,12 +41,14 @@ pub async fn create_test_rpc_service(service: tracey::daemon::TraceyService) -> 
     let (client_transport, server_transport) = memory_transport_pair(256);
     let dispatcher = TraceyDaemonDispatcher::new(service);
 
-    let server_fut = roam::acceptor(server_transport).establish::<TraceyDaemonClient>(dispatcher);
-    let client_fut = roam::initiator(client_transport).establish::<TraceyDaemonClient>(());
+    let server_fut = vox::acceptor_on(server_transport)
+        .on_connection(dispatcher)
+        .establish::<TraceyDaemonClient>();
+    let client_fut = vox::initiator_on(client_transport).establish::<TraceyDaemonClient>();
     let (server_result, client_result) = tokio::try_join!(server_fut, client_fut)
-        .expect("failed to establish in-memory roam transport");
-    let (server_client, _server_session_handle) = server_result;
-    let (client, _client_session_handle) = client_result;
+        .expect("failed to establish in-memory Vox transport");
+    let server_client = server_result;
+    let client = client_result;
     debug!("create_test_rpc_service: server+client established");
 
     RpcTestService {

--- a/crates/tracey/tests/integration_tests.rs
+++ b/crates/tracey/tests/integration_tests.rs
@@ -12,7 +12,7 @@ use tracey_proto::*;
 // Re-export test modules
 mod common;
 
-fn rpc<T, E: std::fmt::Debug>(res: Result<T, roam::RoamError<E>>) -> T {
+fn rpc<T, E: std::fmt::Debug>(res: Result<T, vox::VoxError<E>>) -> T {
     res.expect("RPC call failed")
 }
 

--- a/crates/tracey/tests/lsp_diagnostic_lifecycle_tests.rs
+++ b/crates/tracey/tests/lsp_diagnostic_lifecycle_tests.rs
@@ -16,7 +16,7 @@ use tracey_proto::*;
 
 mod common;
 
-fn rpc<T, E: std::fmt::Debug>(res: Result<T, roam::RoamError<E>>) -> T {
+fn rpc<T, E: std::fmt::Debug>(res: Result<T, vox::VoxError<E>>) -> T {
     res.expect("RPC call failed")
 }
 

--- a/crates/tracey/tests/mcp_tests.rs
+++ b/crates/tracey/tests/mcp_tests.rs
@@ -11,7 +11,7 @@ use tracey_proto::*;
 
 mod common;
 
-fn rpc<T, E: std::fmt::Debug>(res: Result<T, roam::RoamError<E>>) -> T {
+fn rpc<T, E: std::fmt::Debug>(res: Result<T, vox::VoxError<E>>) -> T {
     res.expect("RPC call failed")
 }
 

--- a/crates/tracey/tests/sdoc_corpus_smoke.rs
+++ b/crates/tracey/tests/sdoc_corpus_smoke.rs
@@ -38,9 +38,7 @@ struct Counts {
 #[ignore]
 async fn upstream_strictdoc_corpus_smoke() {
     let Ok(roots_str) = std::env::var("STRICTDOC_CORPUS") else {
-        eprintln!(
-            "skipping: STRICTDOC_CORPUS env var not set; see test file docs"
-        );
+        eprintln!("skipping: STRICTDOC_CORPUS env var not set; see test file docs");
         return;
     };
 
@@ -133,8 +131,7 @@ async fn walk_corpus(root: &Path, corpus: &mut Counts, overall: &mut Counts) {
             Err(e) => {
                 corpus.err += 1;
                 overall.err += 1;
-                let short =
-                    e.to_string().lines().next().unwrap_or("").to_string();
+                let short = e.to_string().lines().next().unwrap_or("").to_string();
                 *corpus.errors.entry(short.clone()).or_insert(0) += 1;
                 *overall.errors.entry(short).or_insert(0) += 1;
             }

--- a/crates/tracey/tests/watcher_tests.rs
+++ b/crates/tracey/tests/watcher_tests.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 
 use tracey::daemon::watcher::{WatcherState, glob_to_watch_dir};
 
-fn rpc<T, E: std::fmt::Debug>(res: Result<T, roam::RoamError<E>>) -> T {
+fn rpc<T, E: std::fmt::Debug>(res: Result<T, vox::VoxError<E>>) -> T {
     res.expect("RPC call failed")
 }
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -17,3 +17,8 @@ targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-
 install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
+# Use bearcove self-hosted runners for all Linux release jobs.
+[dist.github-custom-runners]
+global = "bearcove-ubuntu-24.04"
+aarch64-unknown-linux-gnu = "bearcove-ubuntu-24.04"
+x86_64-unknown-linux-gnu = "bearcove-ubuntu-24.04"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -12,14 +12,15 @@ github-build-setup = "../build-setup.yml"
 # The installers to generate for each app
 installers = ["shell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
-# Use bearcove self-hosted runners for all Linux release jobs.
+# Use bearcove for x64 Linux release jobs, but GitHub-hosted ARM for Linux ARM.
 allow-dirty = ["ci"]
 
 [dist.github-custom-runners]
 global = "bearcove-ubuntu-24.04"
+aarch64-unknown-linux-gnu = "ubuntu-24.04-arm"
 x86_64-unknown-linux-gnu = "bearcove-ubuntu-24.04"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -12,7 +12,7 @@ github-build-setup = "../build-setup.yml"
 # The installers to generate for each app
 installers = ["shell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu"]
+targets = ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program
@@ -22,5 +22,4 @@ allow-dirty = ["ci"]
 
 [dist.github-custom-runners]
 global = "bearcove-ubuntu-24.04"
-aarch64-unknown-linux-gnu = "bearcove-ubuntu-24.04"
 x86_64-unknown-linux-gnu = "bearcove-ubuntu-24.04"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,7 +4,7 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.30.2"
+cargo-dist-version = "0.32.0"
 # CI backends to support
 ci = "github"
 # Extra setup steps injected into generated GitHub build jobs

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -18,6 +18,8 @@ install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
 # Use bearcove self-hosted runners for all Linux release jobs.
+allow-dirty = ["ci"]
+
 [dist.github-custom-runners]
 global = "bearcove-ubuntu-24.04"
 aarch64-unknown-linux-gnu = "bearcove-ubuntu-24.04"

--- a/docs/content/spec/tracey.md
+++ b/docs/content/spec/tracey.md
@@ -829,7 +829,7 @@ The server MUST maintain a version identifier that changes when any source data 
 
 ## Daemon Architecture
 
-Tracey uses a daemon architecture where a single persistent daemon per workspace owns all state and computation. Protocol bridges (HTTP, LSP, MCP) connect as clients to the daemon via roam RPC over Unix sockets.
+Tracey uses a daemon architecture where a single persistent daemon per workspace owns all state and computation. Protocol bridges (HTTP, LSP, MCP) connect as clients to the daemon via Vox RPC over Unix sockets.
 
 ### Daemon Lifecycle
 
@@ -859,15 +859,15 @@ The daemon MUST maintain a virtual filesystem (VFS) overlay that stores in-memor
 r[daemon.state.blocking-rebuild]
 On file changes, the daemon MUST block all incoming requests until the rebuild completes. This ensures clients never see stale or inconsistent data.
 
-### roam Service
+### Vox Service
 
-r[daemon.roam.protocol]
-The daemon MUST expose a `TraceyDaemon` service via the roam RPC protocol.
+r[daemon.vox.protocol]
+The daemon MUST expose a `TraceyDaemon` service via the Vox RPC protocol.
 
-r[daemon.roam.unix-socket]
+r[daemon.vox.unix-socket]
 Communication between the daemon and bridges MUST occur over Unix domain sockets.
 
-r[daemon.roam.framing]
+r[daemon.vox.framing]
 Messages on the Unix socket MUST use COBS framing for reliable message boundary detection.
 
 ### VFS Overlay
@@ -887,13 +887,13 @@ When computing coverage, VFS overlay content MUST take precedence over disk cont
 ### Protocol Bridges
 
 r[daemon.bridge.http]
-The HTTP bridge MUST translate REST API requests to roam RPC calls and serve the dashboard frontend.
+The HTTP bridge MUST translate REST API requests to Vox RPC calls and serve the dashboard frontend.
 
 r[daemon.bridge.mcp]
-The MCP bridge MUST translate MCP tool calls to roam RPC calls, providing AI assistants access to coverage data.
+The MCP bridge MUST translate MCP tool calls to Vox RPC calls, providing AI assistants access to coverage data.
 
 r[daemon.bridge.lsp]
-The LSP bridge MUST translate LSP protocol messages to roam RPC calls and feed the VFS overlay with document open/change/close events.
+The LSP bridge MUST translate LSP protocol messages to Vox RPC calls and feed the VFS overlay with document open/change/close events.
 
 ### CLI Commands
 


### PR DESCRIPTION
## Summary

Prepares Tracey for the Facet/Vox/Styx prerelease stack by bumping the workspace to 2.0.0-rc.0 and moving the daemon RPC path from Roam to Vox 0.9.0-rc.0.

## Changes

- Bumps Tracey workspace crates to 2.0.0-rc.0 and updates Facet, Figue, Styx, and Vox dependencies to the published prerelease versions.
- Updates the Tracey daemon/bridge/test RPC code for Vox, including the owned Reborrow marker required for streamed DataUpdate payloads.
- Moves the dashboard pnpm build approval config into pnpm-workspace.yaml and makes the build script run pnpm non-interactively.
- Regenerates dashboard API types from the updated Rust API shapes.

## Verification

- cargo fmt --all --check
- cargo check --all-features --all-targets --message-format=short
- cargo nextest run --workspace --all-features
- cargo package --workspace --allow-dirty
