### PR TITLE
Add Rego (.rego) language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,7 @@ dependencies = [
  "arborium-powershell",
  "arborium-python",
  "arborium-r",
+ "arborium-rego",
  "arborium-ruby",
  "arborium-rust",
  "arborium-scala",
@@ -632,6 +633,17 @@ name = "arborium-r"
 version = "2.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "305294a9e5742a0228800118e6460dd6fb1ac61b0ba76316141fcfbef3016ccc"
+dependencies = [
+ "arborium-sysroot",
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "arborium-rego"
+version = "2.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c878ffc4dfa1c5b6e94e01d0dd0796bc943096af90bef563b8306766a3e3f518"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -6030,6 +6042,7 @@ dependencies = [
  "arborium-powershell",
  "arborium-python",
  "arborium-r",
+ "arborium-rego",
  "arborium-ruby",
  "arborium-rust",
  "arborium-svelte",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ arborium = { version = "2.16.0", features = [
   "lang-nix",
   "lang-lean",
   "lang-svelte",
+  "lang-rego",
 ] }
 arborium-rust = "2.16.0"
 arborium-swift = "2.16.0"
@@ -130,6 +131,7 @@ arborium-nix = "2.16.0"
 arborium-lean = "2.16.0"
 arborium-yaml = "2.16.0"
 arborium-svelte = "2.17.0"
+arborium-rego = "2.16.0"
 arborium-typst = "2.16.0"
 arborium-tree-sitter = "2.16.0"
 

--- a/crates/tracey-core/Cargo.toml
+++ b/crates/tracey-core/Cargo.toml
@@ -55,6 +55,7 @@ reverse = [
   "dep:arborium-lean",
   "dep:arborium-yaml",
   "dep:arborium-svelte",
+  "dep:arborium-rego",
 ]
 
 [dependencies]
@@ -117,6 +118,7 @@ arborium-nix = { workspace = true, optional = true }
 arborium-lean = { workspace = true, optional = true }
 arborium-yaml = { workspace = true, optional = true }
 arborium-svelte = { workspace = true, optional = true }
+arborium-rego = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/tracey-core/src/code_units.rs
+++ b/crates/tracey-core/src/code_units.rs
@@ -1127,6 +1127,188 @@ fn svelte_node_kind(kind: &str) -> Option<CodeUnitKind> {
     }
 }
 
+/// Extract code units from Rego source code.
+///
+/// Only `rule` nodes become units: the grammar's `package` node is just the
+/// keyword (its name `ref` is a sibling), and `module` spans the whole file —
+/// emitting either would add a noise unit per file.
+///
+/// Known limitations — the tree-sitter-rego grammar predates OPA v1 syntax:
+/// it parses a v1 dangling-if rule (`x := 1 if { ... }`) as the value head
+/// plus a separate phantom rule whose head variable is `if`
+/// (<https://github.com/FallenAngel97/tree-sitter-rego/issues/20>). The
+/// common shapes are merged back below; complex `else` chains and rules
+/// following an `else := value` clause may still yield imperfect extents.
+/// The grammar also lexes `#` inside string literals as a comment start
+/// (<https://github.com/FallenAngel97/tree-sitter-rego/issues/21>), which
+/// can corrupt the parse of everything after the string — requirement
+/// references are still collected from real comments, but code units in
+/// such files may be wrong or missing.
+pub fn extract_rego(path: &Path, source: &str) -> CodeUnits {
+    let mut parser = Parser::new();
+    parser
+        .set_language(&arborium_rego::language().into())
+        .expect("Failed to load Rego grammar");
+
+    let Some(tree) = parser.parse(source, None) else {
+        return CodeUnits::new();
+    };
+
+    let mut units = CodeUnits::new();
+    extract_rego_recursive(path, source, tree.root_node(), &mut units);
+    units
+}
+
+fn extract_rego_recursive(path: &Path, source: &str, node: Node, units: &mut CodeUnits) {
+    if node.kind() == "rule" {
+        if let Some(prev_unit) = rego_dangling_if_target(source, node, units) {
+            // This node is the phantom guard of the preceding value head —
+            // one rule in the source, so one unit.
+            prev_unit.end_line = node.end_position().row + 1;
+            prev_unit.end_byte = node.end_byte();
+        } else {
+            let (req_refs, comment_line) = rego_preceding_comments(source, node);
+            // r[impl code-unit.boundary.include-comments]
+            let start_line = comment_line.unwrap_or(node.start_position().row + 1);
+            let start_byte = match comment_line {
+                Some(line) => find_line_start_byte(source, line),
+                None => node.start_byte(),
+            };
+            units.units.push(CodeUnit {
+                kind: CodeUnitKind::Function,
+                name: rego_rule_name(source, node),
+                file: path.to_path_buf(),
+                start_line,
+                end_line: node.end_position().row + 1,
+                start_byte,
+                end_byte: node.end_byte(),
+                req_refs,
+            });
+        }
+        // Rules never nest; nothing inside one is a unit of its own.
+        return;
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        extract_rego_recursive(path, source, child, units);
+    }
+}
+
+/// First `fn_name` or `var` in document order — the grammar has no fields
+/// and no `identifier` kind, so this is how a rule head is found.
+fn rego_head_ident<'a>(node: Node<'a>) -> Option<Node<'a>> {
+    if matches!(node.kind(), "fn_name" | "var") {
+        return Some(node);
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if let Some(found) = rego_head_ident(child) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// A rule's name: the head identifier extended across `.` segments
+/// (`aws.iam.deny` is one dotted name, but the grammar splits it into
+/// separate nodes).
+fn rego_rule_name(source: &str, rule: Node) -> Option<String> {
+    let ident = rego_head_ident(rule)?;
+    let start = ident.start_byte();
+    let bytes = source.as_bytes();
+    let mut end = ident.end_byte();
+    while end < bytes.len()
+        && (bytes[end] == b'.' || bytes[end] == b'_' || bytes[end].is_ascii_alphanumeric())
+    {
+        end += 1;
+    }
+    Some(source[start..end].trim_end_matches('.').to_string())
+}
+
+/// Own-line comments directly above a rule, chained by line adjacency.
+/// The first rule's comments sit outside the token-less `policy` wrapper in
+/// the parse tree, so when a level has no preceding siblings the walk
+/// continues above the wrapper.
+fn rego_preceding_comments(source: &str, node: Node) -> (Vec<RuleId>, Option<usize>) {
+    let mut refs = Vec::new();
+    let mut earliest_line = None;
+    let mut expected_row = node.start_position().row;
+    let mut cursor = node;
+    loop {
+        match cursor.prev_named_sibling() {
+            Some(prev) if prev.kind() == "comment" => {
+                let line_start = prev.start_byte() - prev.start_position().column;
+                let own_line = source[line_start..prev.start_byte()]
+                    .bytes()
+                    .all(|b| b == b' ' || b == b'\t');
+                if !own_line || prev.end_position().row + 1 < expected_row {
+                    break; // trailer of the previous construct, or a gap
+                }
+                collect_comment_refs(source, prev, &mut refs);
+                expected_row = prev.start_position().row;
+                earliest_line = Some(expected_row + 1);
+                cursor = prev;
+            }
+            Some(_) => break,
+            None => match cursor.parent() {
+                Some(parent) if parent.kind() == "policy" => cursor = parent,
+                _ => break,
+            },
+        }
+    }
+    (refs, earliest_line)
+}
+
+/// When `rule` is the phantom `if` guard the grammar splits off a v1
+/// dangling-if rule, return the unit of the value head it continues.
+fn rego_dangling_if_target<'u>(
+    source: &str,
+    rule: Node,
+    units: &'u mut CodeUnits,
+) -> Option<&'u mut CodeUnit> {
+    // The head must be the bare `if` var: anything with arguments
+    // (`if["k"]`, `if(x)`) or a bound value (`if := v`) is a legacy rule
+    // that happens to be named `if`.
+    let head = rego_head_ident(rule)?;
+    if &source[head.byte_range()] != "if" {
+        return None;
+    }
+    let after = source[head.end_byte()..].trim_start_matches([' ', '\t']);
+    if after.starts_with(['[', '(', '.']) || after.starts_with(":=") {
+        return None;
+    }
+    if after.starts_with('=') && !after.starts_with("==") {
+        return None;
+    }
+
+    // The predecessor must be an adjacent head this guard can continue: a
+    // rule (not `default`, which never takes a body) without a braced body
+    // of its own.
+    let p = rule.prev_named_sibling()?;
+    let p_text = &source[p.byte_range()];
+    let is_default_decl = p_text
+        .strip_prefix("default")
+        .is_some_and(|rest| rest.starts_with([' ', '\t']));
+    if p.kind() != "rule"
+        || rule.start_position().row > p.end_position().row + 1
+        || is_default_decl
+    {
+        return None;
+    }
+    // The grammar also parses a bound value (`:= true`) as a rule_body, so
+    // only a body that actually opens a brace makes the rule complete.
+    let mut cursor = p.walk();
+    if p.children(&mut cursor).any(|c| {
+        c.kind() == "rule_body" && source[c.byte_range()].trim_start().starts_with('{')
+    }) {
+        return None; // already a complete braced rule
+    }
+
+    let last = units.units.last_mut()?;
+    (last.end_byte == p.end_byte()).then_some(last)
+}
+
 fn extract_units_recursive<F>(
     path: &Path,
     source: &str,
@@ -3272,6 +3454,144 @@ function helper {
             .filter(|u| u.kind == CodeUnitKind::Function)
             .collect();
         assert!(!funcs.is_empty(), "Should find function expressions in Nix");
+    }
+
+    #[test]
+    fn test_rego_code_units() {
+        let source = r#"package authz
+
+# r[impl authz.allow.admin]
+allow {
+    input.user.role == "admin"
+}
+
+# r[impl authz.is_admin]
+is_admin(user) {
+    user.role == "admin"
+}
+"#;
+        let units = extract_rego(Path::new("policy.rego"), source);
+        let names: Vec<_> = units
+            .units
+            .iter()
+            .filter_map(|u| u.name.as_deref())
+            .collect();
+        assert!(names.contains(&"allow"), "rules should be named: {names:?}");
+        assert!(
+            names.contains(&"is_admin"),
+            "function rules should be named: {names:?}"
+        );
+
+        // The first rule's comment attaches outside the `policy` wrapper in
+        // the parse tree; the second's is a plain preceding sibling. Both
+        // association paths must work.
+        for name in ["allow", "is_admin"] {
+            let rule = units
+                .units
+                .iter()
+                .find(|u| u.name.as_deref() == Some(name))
+                .unwrap();
+            assert_eq!(
+                rule.req_refs.len(),
+                1,
+                "annotated rule {name} should carry its req ref"
+            );
+        }
+    }
+
+    #[test]
+    fn test_rego_refs() {
+        let source = r#"package authz
+
+# r[impl authz.deny.unauthenticated]
+deny[msg] {
+    not input.user.authenticated
+    msg := "unauthenticated"
+}
+"#;
+        let refs = extract_refs(Path::new("policy.rego"), source);
+        assert_eq!(refs.len(), 1, "Should find the ref in the # comment");
+        assert_eq!(refs[0].req_id, "authz.deny.unauthenticated");
+    }
+
+    #[test]
+    fn test_rego_code_not_treated_as_refs() {
+        // `r[x]` is valid Rego (a rule/set lookup); outside comments it must
+        // not be picked up as an annotation or produce warnings.
+        let source = "package authz\n\nallow {\n    r[input.user]\n}\n";
+        let extracted = extract_refs_with_warnings(Path::new("policy.rego"), source);
+        assert_eq!(extracted.references.len(), 0);
+        assert_eq!(extracted.warnings.len(), 0);
+    }
+
+    #[test]
+    fn test_rego_v1_dangling_if_merged() {
+        // The grammar splits `allow := true if { ... }` into a value head
+        // plus a phantom rule named `if`; extraction merges them back.
+        for source in [
+            "package p\n\n# r[impl p.allow]\nallow := true if {\n    input.admin\n}\n",
+            "package p\n\n# r[impl p.allow]\nallow := true if input.admin\n",
+        ] {
+            let units = extract_rego(Path::new("policy.rego"), source);
+            let names: Vec<_> = units
+                .units
+                .iter()
+                .filter_map(|u| u.name.as_deref())
+                .collect();
+            assert_eq!(units.units.len(), 1, "for {source:?} got {names:?}");
+            assert_eq!(units.units[0].name.as_deref(), Some("allow"));
+            assert_eq!(units.units[0].req_refs.len(), 1);
+            assert_eq!(
+                units.units[0].end_line as usize,
+                source.lines().count(),
+                "unit spans the guard"
+            );
+        }
+    }
+
+    #[test]
+    fn test_rego_default_prefixed_name_merges() {
+        // A rule NAMED default_ttl is not a `default` declaration; its
+        // dangling if must still merge.
+        let source = "package p\n\ndefault_ttl := 60 if {\n    input.override\n}\n";
+        let units = extract_rego(Path::new("policy.rego"), source);
+        let names: Vec<_> = units
+            .units
+            .iter()
+            .filter_map(|u| u.name.as_deref())
+            .collect();
+        assert_eq!(units.units.len(), 1, "got {names:?}");
+        assert_eq!(units.units[0].name.as_deref(), Some("default_ttl"));
+    }
+
+    #[test]
+    fn test_rego_v0_braced_rule_then_if_rule_kept() {
+        // A legacy rule literally named `if` after a complete braced rule is
+        // its own unit, not a continuation.
+        let source = "package p\n\na { input.x }\nif { input.y }\n";
+        let units = extract_rego(Path::new("policy.rego"), source);
+        assert_eq!(units.units.len(), 2);
+    }
+
+    #[test]
+    fn test_rego_dotted_head_name() {
+        let source = "package p\n\nfoo.bar := 1\n";
+        let units = extract_rego(Path::new("policy.rego"), source);
+        assert_eq!(units.units[0].name.as_deref(), Some("foo.bar"));
+    }
+
+    #[test]
+    fn test_rego_trailing_comment_not_attributed() {
+        // A trailer on the previous rule's closing line is not a leading
+        // annotation for the next rule.
+        let source = "package p\n\na := 1 # r[impl p.a]\nb := 2\n";
+        let units = extract_rego(Path::new("policy.rego"), source);
+        let b = units
+            .units
+            .iter()
+            .find(|u| u.name.as_deref() == Some("b"))
+            .unwrap();
+        assert!(b.req_refs.is_empty(), "trailer stolen by b");
     }
 
     #[test]

--- a/crates/tracey-core/src/languages.rs
+++ b/crates/tracey-core/src/languages.rs
@@ -136,6 +136,7 @@ define_languages! {
     ["nix"]                                 => arborium_nix::language,        code_units::extract_nix,        arborium = "nix";
     ["lean"]                                => arborium_lean::language,       code_units::extract_lean,       arborium = "lean";
     ["svelte"]                              => arborium_svelte::language,     code_units::extract_svelte,     arborium = "svelte";
+    ["rego"]                                => arborium_rego::language,       code_units::extract_rego,       arborium = "rego";
     // YAML and JSON5 are config/data formats: they carry requirement refs in
     // comments (scanned via the grammar) but expose no structural code units,
     // so they share the no-op `extract_config`. JSON5 reuses the TS grammar for
@@ -199,6 +200,9 @@ mod tests {
     fn meta_lookups() {
         assert_eq!(arborium_for_ext("rs"), Some("rust"));
         assert_eq!(devicon_for_ext("rs"), Some("devicon-rust-original"));
+        // rego carries a highlight name but no devicon (none exists for OPA).
+        assert_eq!(arborium_for_ext("rego"), Some("rego"));
+        assert_eq!(devicon_for_ext("rego"), None);
         // ts row deliberately leaves both None.
         assert_eq!(arborium_for_ext("tsx"), None);
         assert_eq!(devicon_for_ext("jsx"), None);


### PR DESCRIPTION
Wires the `arborium-rego` grammar into the language registry so tracey extracts requirement references and code units from Open Policy Agent policies.

## What's included

- **Registry row + Cargo wiring** for `.rego` files (highlight name `rego`, no devicon — none exists for OPA).
- **A self-contained extractor** (`extract_rego`): rules become `Function` units; `package`/`module` nodes are skipped (the package node is just the keyword, and module spans the whole file, so either would add a noise unit per file).
- **Comment-only reference collection**: `r[x]` is valid Rego in rule bodies (a set lookup), so references are collected exclusively from comments via the grammar — never from code.
- **Rule naming**: first `fn_name`/`var` in the head, extended across dotted heads (`foo.bar := 1` names the unit `foo.bar`) since the grammar has no name fields.
- **Comment association**: own-line comments directly above a rule, chained by adjacency. The first rule's comments sit *outside* the token-less `policy` wrapper in the parse tree, so the walk climbs through it. Handled entirely inside the Rego extractor — no changes to the shared association logic.
- **OPA v1 dangling-`if` merge**: the grammar predates v1 syntax and parses `allow := true if { ... }` as a value head plus a phantom rule whose head variable is `if`. Since OPA 1.0 rejects bodied rules *without* `if`, essentially every current policy hits this, so the common shapes are merged back into one unit.

## Known limitations

The remaining grammar gaps are documented in the module doc rather than worked around, with upstream issues filed:

- FallenAngel97/tree-sitter-rego#20 — v1 `if` splits rules; complex `else` chains may still yield imperfect extents.
- FallenAngel97/tree-sitter-rego#21 — `#` inside string literals is lexed as a comment start, which can corrupt the parse after the string. References in real comments still collect; code units in such files may be wrong.

If the grammar gains v1 support, the dangling-`if` merge here becomes dead code and can be dropped.

## Testing

- 8 unit tests covering: v0 rules, both comment-association paths (wrapper climb + plain sibling), `r[x]`-in-code non-refs, v1 dangling-`if` (braced and unbraced), rules named with a `default` prefix (`default_ttl`), legacy rules literally named `if` after a braced rule, dotted head names, and trailing-comment exclusion.
- Verified end-to-end with `tracey query` against sample projects mixing v0 and v1 policies: requirements covered, unannotated rules reported unmapped, no false references from code.